### PR TITLE
fix: route configure failures and controller setter rejections to onError

### DIFF
--- a/packages/react-native-vision-camera-worklets/src/createRuntimeThreadProvider.ts
+++ b/packages/react-native-vision-camera-worklets/src/createRuntimeThreadProvider.ts
@@ -73,7 +73,17 @@ export function createRuntimeThreadProvider(): RuntimeThreadProvider {
       scheduleOnUI(() => {
         'worklet'
         value.addListener(id, (v) => {
-          controller[funcName](v)
+          // Controller setters return Promises; a rejection (e.g. CameraX
+          // OperationCanceledException while the session is re-configuring,
+          // like a pinch-zoom during an fps/constraints change) must not
+          // surface as an unhandled rejection on the UI runtime.
+          controller[funcName](v).catch((e) => {
+            const message =
+              typeof e === 'object' && e != null && 'message' in e
+                ? String(e.message)
+                : `${e}`
+            console.error(message, e)
+          })
         })
       })
       return {

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
@@ -16,6 +16,7 @@ interface Config {
   onSessionConfigSelected?: (config: CameraSessionConfig) => void
 
   onConfigured?: () => void
+  onConfigureError?: (error: Error) => void
   getInitialZoom?: () => number | undefined
   getInitialExposureBias?: () => number | undefined
 }
@@ -38,6 +39,7 @@ export function useCameraController(
     allowBackgroundAudioPlayback,
     getInitialExposureBias,
     onConfigured,
+    onConfigureError,
     getInitialZoom,
   }: Config = {},
 ): CameraController | undefined {
@@ -52,6 +54,7 @@ export function useCameraController(
     getInitialZoom ?? (() => undefined),
   )
   const stableOnConfigured = useStableCallback(onConfigured ?? (() => {}))
+  const stableOnConfigureError = useStableCallback(onConfigureError ?? (() => {}))
   const stableOnSessionConfigSelected = useStableCallback(
     onSessionConfigSelected ?? (() => {}),
   )
@@ -83,23 +86,38 @@ export function useCameraController(
         session.configure([], {})
         setController(undefined)
       } else {
+        // Build the connection before the try - a throw from a user-supplied
+        // getter here is a caller bug, not a configure failure, and must not
+        // be misreported through onConfigureError.
+        const connection = {
+          input: device,
+          outputs: stableOutputs.map((o) => ({
+            output: o,
+            mirrorMode: mirrorMode,
+          })),
+          constraints: stableConstraints,
+          initialExposureBias: stableGetInitialExposureBias?.(),
+          initialZoom: stableGetInitialZoom?.(),
+          onSessionConfigSelected: stableOnSessionConfigSelected,
+        }
         // Device + outputs - configure session
-        const controllers = await session.configure(
-          [
-            {
-              input: device,
-              outputs: stableOutputs.map((o) => ({
-                output: o,
-                mirrorMode: mirrorMode,
-              })),
-              constraints: stableConstraints,
-              initialExposureBias: stableGetInitialExposureBias?.(),
-              initialZoom: stableGetInitialZoom?.(),
-              onSessionConfigSelected: stableOnSessionConfigSelected,
-            },
-          ],
-          { allowBackgroundAudioPlayback: allowBackgroundAudioPlayback },
-        )
+        let controllers: CameraController[]
+        try {
+          controllers = await session.configure([connection], {
+            allowBackgroundAudioPlayback: allowBackgroundAudioPlayback,
+          })
+        } catch (e) {
+          // A rejected configure() means the session could never be built
+          // (e.g. the device rejected the use-case combination). Without this
+          // handler the rejection is silently swallowed: no controller, no
+          // onError, and the preview stays black forever. Surface it to the
+          // user's onError.
+          if (isCanceled) return
+          setController(undefined)
+          const error = e instanceof Error ? e : new Error(String(e))
+          stableOnConfigureError(error)
+          return
+        }
         if (isCanceled) {
           controllers.forEach((c) => {
             c.dispose()
@@ -121,6 +139,7 @@ export function useCameraController(
     allowBackgroundAudioPlayback,
     stableOutputs,
     stableOnConfigured,
+    stableOnConfigureError,
     stableGetInitialExposureBias,
     stableGetInitialZoom,
     stableOnSessionConfigSelected,

--- a/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useExposureUpdater.ts
@@ -2,22 +2,32 @@ import { useEffect } from 'react'
 import type { SharedValue } from 'react-native-reanimated'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import { VisionCameraWorkletsProxy } from '../../third-party/VisionCameraWorkletsProxy'
+import { useStableCallback } from './useStableCallback'
 
 export function useExposureUpdater(
   controller: CameraController | undefined,
   exposure: number | SharedValue<number> | undefined,
+  onError?: (error: Error) => void,
 ): void {
+  const stableOnError = useStableCallback(onError ?? console.error)
   useEffect(() => {
     if (controller == null) return
     if (exposure == null) return
 
+    // Fire-and-forget Promise - see the note in useZoomUpdater. Route
+    // rejections to the user's onError instead of letting them surface as
+    // unhandled Promise rejections.
+    const applyExposure = (value: number) => {
+      controller.setExposureBias(value).catch(stableOnError)
+    }
+
     if (typeof exposure === 'number') {
       // number
-      controller.setExposureBias(exposure)
+      applyExposure(exposure)
       return
     } else {
       // SharedValue<number>
-      controller.setExposureBias(exposure.get())
+      applyExposure(exposure.get())
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         exposure,
         controller,
@@ -25,5 +35,5 @@ export function useExposureUpdater(
       )
       return () => listener.remove()
     }
-  }, [controller, exposure])
+  }, [controller, exposure, stableOnError])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useTorchModeUpdater.ts
@@ -1,15 +1,22 @@
 import { useEffect } from 'react'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import type { TorchMode } from '../../specs/common-types/TorchMode'
+import { useStableCallback } from './useStableCallback'
 
 export function useTorchModeUpdater(
   controller: CameraController | undefined,
   torchMode: TorchMode | undefined,
+  onError?: (error: Error) => void,
 ): void {
+  const stableOnError = useStableCallback(onError ?? console.error)
   useEffect(() => {
     if (controller == null) return
     if (torchMode == null) return
 
-    controller.setTorchMode(torchMode)
-  }, [controller, torchMode])
+    // Fire-and-forget Promise - see the note in useZoomUpdater. Also rejects
+    // with "No flash unit" on devices/lenses without a torch. Route
+    // rejections to the user's onError instead of letting them surface as
+    // unhandled Promise rejections.
+    controller.setTorchMode(torchMode).catch(stableOnError)
+  }, [controller, torchMode, stableOnError])
 }

--- a/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useZoomUpdater.ts
@@ -2,22 +2,35 @@ import { useEffect } from 'react'
 import type { SharedValue } from 'react-native-reanimated'
 import type { CameraController } from '../../specs/CameraController.nitro'
 import { VisionCameraWorkletsProxy } from '../../third-party/VisionCameraWorkletsProxy'
+import { useStableCallback } from './useStableCallback'
 
 export function useZoomUpdater(
   controller: CameraController | undefined,
   zoom: number | SharedValue<number> | undefined,
+  onError?: (error: Error) => void,
 ): void {
+  const stableOnError = useStableCallback(onError ?? console.error)
   useEffect(() => {
     if (controller == null) return
     if (zoom == null) return
 
+    // setZoom returns a Promise which is fired-and-forgotten here. It can
+    // reject under recoverable conditions - e.g. CameraX rejects with
+    // OperationCanceledException ("Camera is not active") when this effect
+    // re-runs against a freshly re-configured, not-yet-streaming session.
+    // Route the rejection to the user's onError instead of letting it
+    // surface as an unhandled Promise rejection.
+    const applyZoom = (value: number) => {
+      controller.setZoom(value).catch(stableOnError)
+    }
+
     if (typeof zoom === 'number') {
       // number
-      controller.setZoom(zoom)
+      applyZoom(zoom)
       return
     } else {
       // SharedValue<number>
-      controller.setZoom(zoom.get())
+      applyZoom(zoom.get())
       const listener = VisionCameraWorkletsProxy.bindUIUpdatesToController(
         zoom,
         controller,
@@ -25,5 +38,5 @@ export function useZoomUpdater(
       )
       return () => listener.remove()
     }
-  }, [controller, zoom])
+  }, [controller, zoom, stableOnError])
 }

--- a/packages/react-native-vision-camera/src/hooks/useCamera.ts
+++ b/packages/react-native-vision-camera/src/hooks/useCamera.ts
@@ -279,6 +279,10 @@ export function useCamera({
   const controller = useCameraController(session, input, outputs, {
     mirrorMode: mirrorMode,
     onConfigured: onConfigured,
+    // Route session-configure failures to the same onError the runtime
+    // session errors use - a swallowed configure() rejection otherwise
+    // leaves a permanent black preview with no error surfaced at all.
+    onConfigureError: onError,
     getInitialExposureBias: getInitialExposureBias,
     getInitialZoom: getInitialZoom,
     constraints: constraints,

--- a/packages/react-native-vision-camera/src/views/Camera.tsx
+++ b/packages/react-native-vision-camera/src/views/Camera.tsx
@@ -248,9 +248,11 @@ function CameraImpl({
   )
 
   // 6. Update CameraController props
-  useZoomUpdater(controller, zoom)
-  useExposureUpdater(controller, exposure)
-  useTorchModeUpdater(controller, torchMode)
+  // Controller setter rejections are routed to the same `onError` the
+  // session's runtime errors use.
+  useZoomUpdater(controller, zoom, props.onError)
+  useExposureUpdater(controller, exposure, props.onError)
+  useTorchModeUpdater(controller, torchMode, props.onError)
 
   // 7. Attach any native gesture controllers
   if (enableNativeZoomGesture && zoom != null) {


### PR DESCRIPTION
## What

Two classes of camera errors are currently lost, both fixed by routing them to the existing `onError` from `useCamera` — following the direction given in #4031 (*"We should have an explicit `onError` parameter, which is gonna be the one we received from the `useCamera` hook."*).

### 1. `session.configure()` rejections are silently swallowed → permanent black preview

In `useCameraController`, the `await session.configure(...)` inside the effect's async `load()` has no catch. If the device can't build the session (e.g. it rejects the use-case combination — we hit this in production with a `PRIVATE`-format analysis use-case on Samsung S22 Ultra and others, confirmed via Crashlytics), the rejection disappears: **no controller, no `onError`, and the preview stays black forever** with nothing surfaced anywhere.

`configure()` failures are now caught and routed to a new internal `onConfigureError`, which `useCamera` wires to its `onError`. The connection object is built *before* the try so a throw from a user-supplied getter (a caller bug) isn't misreported as a configure failure.

### 2. Controller setter rejections surface as unhandled Promise rejections

`useZoomUpdater` / `useExposureUpdater` / `useTorchModeUpdater` fire-and-forget `setZoom` / `setExposureBias` / `setTorchMode`. These reject under recoverable, real-world conditions:

- CameraX `OperationCanceledException` ("Camera is not active") when the effect re-runs against a freshly re-configured, not-yet-streaming session (any `constraints`/fps change while `zoom` is set)
- `IllegalStateException: No flash unit` for torch on front cameras/emulators

The rejection bubbles to the global unhandled-rejection handler — full-screen RedBox in dev, crash-reporter noise in prod. The hooks now take an optional `onError` (passed from the `Camera` view's props); callers without one fall back to `console.error`, matching `useCamera`'s `defaultOnErrorHandler`.

### Worklets listener path

The same setters are also called from the `SharedValue` listener worklet in `react-native-vision-camera-worklets` (`bindUIUpdatesToController`), on the UI runtime where no `onError` is reachable without changing the `RuntimeThreadProvider` interface. Rejections there are caught and logged via `console.error`, matching the existing error convention for frame/depth callbacks in that same file. Happy to extend `bindUIUpdatesToController` with an error callback instead if you'd prefer that.

## Testing

Both fixes have been running in production in our scanner app (5.1.1 + patch-package): configure failures now surface to `onError` (we use it to fall back to a different pixel format), and pinch-zoom during session re-configuration no longer RedBoxes in dev.
