### PR TITLE
feat(resizer): add 'stretch' ScaleMode

### DIFF
--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanResizerShaderConfig.cpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanResizerShaderConfig.cpp
@@ -107,6 +107,8 @@ uint32_t ShaderSpecializationData::getScaleModeOrdinal(ScaleMode scaleMode) {
       return 0u;
     case ScaleMode::CONTAIN:
       return 1u;
+    case ScaleMode::STRETCH:
+      return 2u;
   }
 
   throw std::runtime_error("Unsupported Resizer ScaleMode.");

--- a/packages/react-native-vision-camera-resizer/android/src/main/shaders/Resizer.comp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/shaders/Resizer.comp
@@ -12,7 +12,7 @@ layout(constant_id = 1) const uint kChannelOrder = 0u;
 layout(constant_id = 2) const uint kPixelLayout = 0u;
 // Number of channels per pixel. e.g. for RGB/BGR, this is 3u.
 layout(constant_id = 3) const uint kChannelCount = 0u;
-// 0u == ScaleMode::COVER, 1u == ScaleMode::CONTAIN
+// 0u == ScaleMode::COVER, 1u == ScaleMode::CONTAIN, 2u == ScaleMode::STRETCH
 layout(constant_id = 4) const uint kScaleMode = 0u;
 
 // The output buffer is addressed as 32-bit words. It must be pre-zeroed before dispatch
@@ -53,29 +53,36 @@ vec2 outputToInputCoordinate(uvec2 gid) {
   vec2 sourceSize = vec2(textureSize(inputImage, 0));
   vec2 outputCoordinate = (vec2(gid) + vec2(0.5)) / outputSize;
 
-  float scale = 0.0;
+  vec2 coordinate;
   switch (kScaleMode) {
-    case 0u: // 0u == ScaleMode::COVER
-      scale = max(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+    case 0u: { // 0u == ScaleMode::COVER
+      float scale = max(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+      vec2 renderedSourceSizeInOutput = sourceSize * scale;
+      vec2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5;
+      coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
       break;
-    case 1u: // 1u == ScaleMode::CONTAIN
-      scale = min(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+    }
+    case 1u: { // 1u == ScaleMode::CONTAIN
+      float scale = min(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+      vec2 renderedSourceSizeInOutput = sourceSize * scale;
+      vec2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5;
+      coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
+      // Contain mode pads outside the rendered source with black bars.
+      bool isOutsideSource = coordinate.x < 0.0 || coordinate.x > 1.0 || coordinate.y < 0.0 || coordinate.y > 1.0;
+      if (isOutsideSource) {
+        return vec2(-1.0);
+      }
       break;
+    }
+    case 2u: { // 2u == ScaleMode::STRETCH
+      // Independent per-axis stretching: the entire source [0,1]^2 maps to the
+      // entire output [0,1]^2. Aspect ratio is NOT preserved.
+      coordinate = outputCoordinate;
+      break;
+    }
     default:
       // Unsupported ScaleMode specialization. Force out-of-bounds so the caller gets black.
       return vec2(-1.0);
-  }
-
-  vec2 renderedSourceSizeInOutput = sourceSize * scale;
-  vec2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5;
-  vec2 coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
-
-  if (kScaleMode == 1u) {
-    // Contain mode pads outside the rendered source with black bars.
-    bool isOutsideSource = coordinate.x < 0.0 || coordinate.x > 1.0 || coordinate.y < 0.0 || coordinate.y > 1.0;
-    if (isOutsideSource) {
-      return vec2(-1.0);
-    }
   }
 
   if (pushConstants.isMirrored == 1u) {

--- a/packages/react-native-vision-camera-resizer/ios/Metal/ResizerKernels.metal
+++ b/packages/react-native-vision-camera-resizer/ios/Metal/ResizerKernels.metal
@@ -16,7 +16,7 @@ constant uint kChannelOrder [[function_constant(0)]];
 constant uint kPixelLayout [[function_constant(1)]];
 // Number of channels per pixel. e.g. for RGB/BGR, this is 3u.
 constant uint kChannelCount [[function_constant(2)]];
-// 0u == ScaleMode::COVER, 1u == ScaleMode::CONTAIN
+// 0u == ScaleMode::COVER, 1u == ScaleMode::CONTAIN, 2u == ScaleMode::STRETCH
 constant uint kScaleMode [[function_constant(3)]];
 
 inline float3 yuvToRgb(float y, float2 uv) {
@@ -40,29 +40,36 @@ inline float3 sampleRgb(
   float2 sourceSize = float2(yTexture.get_width(), yTexture.get_height());
   float2 outputCoordinate = (float2(gid) + 0.5f) / outputSize;
 
-  float scale = 0.0f;
+  float2 coordinate;
   switch (kScaleMode) {
-    case 0u: // 0u == ScaleMode::COVER
-      scale = max(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+    case 0u: { // 0u == ScaleMode::COVER
+      float scale = max(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+      float2 renderedSourceSizeInOutput = sourceSize * scale;
+      float2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5f;
+      coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
       break;
-    case 1u: // 1u == ScaleMode::CONTAIN
-      scale = min(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+    }
+    case 1u: { // 1u == ScaleMode::CONTAIN
+      float scale = min(outputSize.x / sourceSize.x, outputSize.y / sourceSize.y);
+      float2 renderedSourceSizeInOutput = sourceSize * scale;
+      float2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5f;
+      coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
+      // Contain mode pads outside the rendered source with black bars.
+      bool isOutsideSource = coordinate.x < 0.0f || coordinate.x > 1.0f || coordinate.y < 0.0f || coordinate.y > 1.0f;
+      if (isOutsideSource) {
+        return float3(0.0f);
+      }
       break;
+    }
+    case 2u: { // 2u == ScaleMode::STRETCH
+      // Independent per-axis stretching: the entire source [0,1]^2 maps to the
+      // entire output [0,1]^2. Aspect ratio is NOT preserved.
+      coordinate = outputCoordinate;
+      break;
+    }
     default:
       // Unsupported ScaleMode ordinal. Return black so broken modes fail visibly at runtime.
       return float3(0.0f);
-  }
-
-  float2 renderedSourceSizeInOutput = sourceSize * scale;
-  float2 renderedSourceOffsetInOutput = (outputSize - renderedSourceSizeInOutput) * 0.5f;
-  float2 coordinate = ((outputCoordinate * outputSize) - renderedSourceOffsetInOutput) / renderedSourceSizeInOutput;
-
-  if (kScaleMode == 1u) {
-    // Contain mode pads outside the rendered source with black bars.
-    bool isOutsideSource = coordinate.x < 0.0f || coordinate.x > 1.0f || coordinate.y < 0.0f || coordinate.y > 1.0f;
-    if (isOutsideSource) {
-      return float3(0.0f);
-    }
   }
 
   // Apply mirror first, then inverse rotation transform to map output->input.

--- a/packages/react-native-vision-camera-resizer/ios/Utils/OutputFormat+Resizer.swift
+++ b/packages/react-native-vision-camera-resizer/ios/Utils/OutputFormat+Resizer.swift
@@ -65,6 +65,8 @@ extension ScaleMode {
       return 0
     case .contain:
       return 1
+    case .stretch:
+      return 2
     }
   }
 }

--- a/packages/react-native-vision-camera-resizer/nitrogen/generated/ios/swift/ScaleMode.swift
+++ b/packages/react-native-vision-camera-resizer/nitrogen/generated/ios/swift/ScaleMode.swift
@@ -21,6 +21,8 @@ public extension ScaleMode {
         self = .cover
       case "contain":
         self = .contain
+      case "stretch":
+        self = .stretch
       default:
         return nil
     }
@@ -35,6 +37,8 @@ public extension ScaleMode {
         return "cover"
       case .contain:
         return "contain"
+      case .stretch:
+        return "stretch"
     }
   }
 }

--- a/packages/react-native-vision-camera-resizer/nitrogen/generated/shared/c++/ScaleMode.hpp
+++ b/packages/react-native-vision-camera-resizer/nitrogen/generated/shared/c++/ScaleMode.hpp
@@ -31,6 +31,7 @@ namespace margelo::nitro::camera::resizer {
   enum class ScaleMode {
     COVER      SWIFT_NAME(cover) = 0,
     CONTAIN      SWIFT_NAME(contain) = 1,
+    STRETCH      SWIFT_NAME(stretch) = 2,
   } CLOSED_ENUM;
 
 } // namespace margelo::nitro::camera::resizer
@@ -45,6 +46,7 @@ namespace margelo::nitro {
       switch (hashString(unionValue.c_str(), unionValue.size())) {
         case hashString("cover"): return margelo::nitro::camera::resizer::ScaleMode::COVER;
         case hashString("contain"): return margelo::nitro::camera::resizer::ScaleMode::CONTAIN;
+        case hashString("stretch"): return margelo::nitro::camera::resizer::ScaleMode::STRETCH;
         default: [[unlikely]]
           throw std::invalid_argument("Cannot convert \"" + unionValue + "\" to enum ScaleMode - invalid value!");
       }
@@ -53,6 +55,7 @@ namespace margelo::nitro {
       switch (arg) {
         case margelo::nitro::camera::resizer::ScaleMode::COVER: return JSIConverter<std::string>::toJSI(runtime, "cover");
         case margelo::nitro::camera::resizer::ScaleMode::CONTAIN: return JSIConverter<std::string>::toJSI(runtime, "contain");
+        case margelo::nitro::camera::resizer::ScaleMode::STRETCH: return JSIConverter<std::string>::toJSI(runtime, "stretch");
         default: [[unlikely]]
           throw std::invalid_argument("Cannot convert ScaleMode to JS - invalid value: "
                                     + std::to_string(static_cast<int>(arg)) + "!");
@@ -66,6 +69,7 @@ namespace margelo::nitro {
       switch (hashString(unionValue.c_str(), unionValue.size())) {
         case hashString("cover"):
         case hashString("contain"):
+        case hashString("stretch"):
           return true;
         default:
           return false;

--- a/packages/react-native-vision-camera-resizer/src/specs/ResizerFactory.nitro.ts
+++ b/packages/react-native-vision-camera-resizer/src/specs/ResizerFactory.nitro.ts
@@ -12,8 +12,12 @@ import type { Resizer } from './Resizer.nitro'
  *   This performs a centered crop on the longer source axis.
  * - `'contain'`: Keep the full source image visible and preserve aspect ratio.
  *   This adds black bars (letterboxing/pillarboxing) where needed.
+ * - `'stretch'`: Fill the whole output by stretching the input independently
+ *   on each axis. The aspect ratio is NOT preserved — the input is squashed
+ *   or stretched as needed to exactly match the output dimensions. No bars,
+ *   no cropping.
  */
-export type ScaleMode = 'cover' | 'contain'
+export type ScaleMode = 'cover' | 'contain' | 'stretch'
 
 /**
  * Configures options for a {@linkcode Resizer}.
@@ -46,6 +50,8 @@ export interface ResizerOptions {
    * - `'cover'`: Perform a centered crop to fill the full output.
    * - `'contain'`: Keep the full source image and pad remaining output
    *   areas with black bars.
+   * - `'stretch'`: Stretch the input independently on each axis to exactly
+   *   fill the output. Does NOT preserve aspect ratio.
    */
   scaleMode: ScaleMode
   /**


### PR DESCRIPTION
## What

Adds a third `ScaleMode` to `react-native-vision-camera-resizer`: **`'stretch'`** fills the whole output by stretching the input independently on each axis — no black bars, no cropping, aspect ratio **not** preserved.

## Why

ML models with fixed square inputs (e.g. 640×640 detectors) are typically trained on images stretched to square. With only `cover`/`contain` available:

- `cover` center-crops, cutting off detection targets near the frame edges
- `contain` letterboxes, wasting ~44% of a square input tensor on black bars when fed 16:9 camera frames (and shrinking the effective object resolution accordingly)

`stretch` matches the training-time preprocessing exactly and uses every input pixel. We use it in production to feed 16:9 frames into a square keypoint-detection model — accuracy at frame edges improved measurably vs `cover`.

## Implementation

- **Vulkan (Android)** `Resizer.comp` + `VulkanResizerShaderConfig.cpp`: ordinal `2u`; the output coordinate maps 1:1 onto the source `[0,1]²` per axis. The `cover`/`contain` math is unchanged, just moved into per-case blocks since `stretch` has no scale factor or centering offset.
- **Metal (iOS)** `ResizerKernels.metal` + `OutputFormat+Resizer.swift`: same mapping, ordinal `2`.
- **TS spec** `ResizerFactory.nitro.ts`: `ScaleMode = 'cover' | 'contain' | 'stretch'` + docs.
- **`nitrogen/generated`** `ScaleMode.swift` / `ScaleMode.hpp`: updated to match what `nitrogen` emits for the new union member (happy to re-run `bun specs` if you'd rather the CI regenerate).

Mirroring and rotation are applied after the coordinate mapping, so they compose with `stretch` the same way they do with the existing modes.

## Testing

Running in production on both platforms (Android Vulkan path across Adreno/Mali/Xclipse, iOS Metal path) as a patch-package addition — output tensors verified against CPU-reference stretched resizes.
