### PR TITLE
fix(resizer): bound the AHardwareBuffer import cache (Android)

### DIFF
--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.cpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.cpp
@@ -73,6 +73,14 @@ const VulkanHardwareBufferInterop::ImportedImage& VulkanHardwareBufferInterop::i
     iterator = _cachedImages.erase(iterator);
   }
 
+  // Evict the oldest entries before inserting so old camera sessions' buffers get released.
+  // Safe to destroy here: run() holds _stateMutex across import -> dispatch -> submit-and-wait,
+  // so no imported image is in flight on the GPU at this point.
+  while (_cachedImages.size() >= kMaxCachedImages) {
+    destroyImportedImage(_cachedImages.front().importedImage);
+    _cachedImages.erase(_cachedImages.begin());
+  }
+
   // No suitable ImportedImage was found in our cache - we have to create a new one.
   CachedImage cachedImage{
       .hardwareBuffer = hardwareBuffer,

--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.hpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/vulkan/VulkanHardwareBufferInterop.hpp
@@ -70,6 +70,15 @@ private:
     ImportedImage importedImage{};
   };
 
+  /**
+   * Upper bound on cached imported images (oldest-inserted evicted first).
+   * Importing an AHardwareBuffer into Vulkan acquires a reference on it, so every cached entry
+   * pins a whole camera buffer - each camera session restart allocates a fresh buffer set, and
+   * an unbounded cache pins the old sets forever. A streaming session cycles through ~4-6
+   * buffers, so 12 leaves plenty of slack.
+   */
+  static inline constexpr size_t kMaxCachedImages = 12;
+
   static inline constexpr VkFormatFeatureFlags kRequiredExternalFormatFeatures = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
   static inline constexpr VkFormatFeatureFlags kLinearFilterFeatureMask =
       VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT;


### PR DESCRIPTION
Split out of #4117 ([as requested](https://github.com/mrousavy/react-native-vision-camera/pull/4117#issuecomment-5164805114)), reworked to [keep the `std::vector` and `back()` code as suggested](https://github.com/mrousavy/react-native-vision-camera/pull/4117#issuecomment-5164824629) — the container and hit path are unchanged, the bound is plain oldest-first eviction with no LRU reordering.

Importing an AHardwareBuffer into Vulkan acquires a reference on it, so every entry in the Resizer's unbounded import cache pins a full camera buffer. Each camera session restart (fps/constraints change, pause/resume) makes CameraX allocate a fresh buffer set, so the pinned set grows by a whole set per restart and is never released. Measured on a Pixel 10 over ~49 min with periodic restarts: 39 → 137 retained 1920x1080 buffers (~418 MB of gralloc), total PSS 588 MB → 1.21 GB.

Fix: cap the cache at 12 entries, evicting the oldest-inserted entry before inserting. FIFO is enough — eviction only fires on inserts, and a steady streaming session (~4–6 recycled buffers) is all cache hits, so the worst case is a few one-off re-imports around a restart. Eviction is safe at that point because `run()` holds `_stateMutex` across import → dispatch → submit-and-wait, so nothing is in flight on the GPU.

Tested on device (Pixel 10, Vulkan path): retained-buffer count stays flat across repeated camera restarts instead of ratcheting, and PSS no longer climbs.
