### PR TITLE
fix(resizer): guard dispose() against an in-flight resize()

### DIFF
--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.cpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.cpp
@@ -38,6 +38,8 @@ namespace {
 HybridResizer::HybridResizer(const ResizerOptions& options) : HybridObject(TAG), _pipeline(std::make_unique<vulkan::VulkanResizerPipeline>(options)) {}
 
 std::shared_ptr<HybridGPUFrameSpec> HybridResizer::resize(const std::shared_ptr<camera::HybridFrameSpec>& frame) {
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   if (_pipeline == nullptr) [[unlikely]] {
     throw std::runtime_error("This Resizer has already been disposed!");
   }
@@ -59,6 +61,8 @@ std::shared_ptr<HybridGPUFrameSpec> HybridResizer::resize(const std::shared_ptr<
 }
 
 void HybridResizer::dispose() {
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   if (_pipeline == nullptr) {
     return;
   }
@@ -71,6 +75,10 @@ void HybridResizer::dispose() {
 }
 
 size_t HybridResizer::getExternalMemorySize() noexcept {
+  // Also guarded: Nitro calls this from toObject() on arbitrary threads, and it is never called
+  // from inside resize()/dispose(), so it cannot self-deadlock.
+  std::lock_guard<std::mutex> lock(_lifecycleMutex);
+
   return _pipeline != nullptr ? _pipeline->getOutputBufferAllocationSize() : 0;
 }
 

--- a/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.hpp
+++ b/packages/react-native-vision-camera-resizer/android/src/main/cpp/HybridResizer.hpp
@@ -11,6 +11,7 @@
 #include "vulkan/VulkanResizerPipeline.hpp"
 
 #include <memory>
+#include <mutex>
 
 namespace margelo::nitro::camera::resizer {
 
@@ -28,6 +29,11 @@ public:
   size_t getExternalMemorySize() noexcept override;
 
 private:
+  // Serializes resize() against dispose(): dispose() can run on the JS thread while resize() is
+  // still running on the frame-processor thread, and resetting _pipeline mid-run() tears down the
+  // VkDevice underneath it. A dispose landing mid-frame blocks until that resize returns; every
+  // later call throws the catchable "already been disposed" error.
+  std::mutex _lifecycleMutex;
   std::unique_ptr<vulkan::VulkanResizerPipeline> _pipeline;
 };
 

--- a/packages/react-native-vision-camera-resizer/ios/HybridResizer.swift
+++ b/packages/react-native-vision-camera-resizer/ios/HybridResizer.swift
@@ -12,6 +12,11 @@ import VisionCamera
 
 /// High-level iOS resizer that turns camera frames into GPU-backed JS-visible output frames.
 final class HybridResizer: HybridResizerSpec {
+  /// Serializes `resize()` against `dispose()`: `pipeline` is read on the frame-processor thread
+  /// while `dispose()` clears it on the JS thread, and a Swift class-reference load/store is not
+  /// atomic - `pipeline = nil` racing the `guard let` load is a data race on the possibly-last
+  /// reference.
+  private let lifecycleLock = NSLock()
   private var pipeline: MetalResizerPipeline?
 
   init(options: ResizerOptions) throws {
@@ -20,14 +25,20 @@ final class HybridResizer: HybridResizerSpec {
   }
 
   var memorySize: Int {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     return pipeline?.outputByteCount ?? 0
   }
 
   func dispose() {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     pipeline = nil
   }
 
   func resize(frame: any HybridFrameSpec) throws -> any HybridGPUFrameSpec {
+    lifecycleLock.lock()
+    defer { lifecycleLock.unlock() }
     guard let pipeline else {
       throw RuntimeError.error(withMessage: "This Resizer has already been disposed!")
     }


### PR DESCRIPTION
Split out of #4117 ([as requested](https://github.com/mrousavy/react-native-vision-camera/pull/4117#issuecomment-5164805114)).

`resize()` null-checks `_pipeline` and then dereferences it with no synchronization, while `dispose()` can concurrently reset the same `unique_ptr` from the JS thread — running `~VulkanResizerPipeline()` and tearing down the VkDevice under an in-flight `run()`. That is a native use-after-free instead of the catchable "already been disposed" error. iOS has the same shape: an unguarded `pipeline = nil` racing the `guard let` load is a data race on the possibly-last reference.

Fix: serialize `resize()`, `dispose()` and the `memorySize` getter behind a lifecycle lock (`std::mutex` / `NSLock`). A dispose landing mid-frame blocks until that resize returns; every later call throws the catchable error. The getter is included because Nitro reads it from `toObject()` on arbitrary threads; it is never called from inside `resize()`/`dispose()`, so it cannot self-deadlock.

Tested on device on both platforms: on Android by disposing from an effect cleanup while frames were still being processed, and on iOS where this change has been shipping in our production app as a patch-package patch.
