### PR TITLE
fix(docs): wrap long API member headings on mobile

### DIFF
--- a/docs/src/app/global.css
+++ b/docs/src/app/global.css
@@ -78,7 +78,7 @@ article .prose [data-rmiz] {
   min-width: 0;
 }
 
-.api-reference-layout #nd-page > article :is(h1, h2, h3, h4, h5, h6) {
+.api-reference-layout #nd-page :is(h1, h2, h3, h4, h5, h6) {
   max-width: 100%;
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/docs/tests/mobile-api-layout.spec.ts
+++ b/docs/tests/mobile-api-layout.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test'
+
+test('long API member headings wrap on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 })
+  await page.goto(
+    '/api/react-native-vision-camera/hybrid-objects/CameraController',
+  )
+  await page.waitForLoadState('networkidle')
+
+  const heading = page
+    .locator('h3')
+    .filter({ hasText: 'convertWhiteBalanceTemperatureAndTintValues(...)' })
+  await expect(heading).toBeVisible()
+
+  const metrics = await heading.evaluate((element) => {
+    const link = element.querySelector('a')
+    if (link == null) throw new Error('API member heading link not found')
+
+    const lineHeight = Number.parseFloat(getComputedStyle(link).lineHeight)
+
+    return {
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      headingClientWidth: element.clientWidth,
+      headingScrollWidth: element.scrollWidth,
+      linkHeight: link.getBoundingClientRect().height,
+      lineHeight,
+    }
+  })
+
+  expect(metrics.headingScrollWidth).toBeLessThanOrEqual(
+    metrics.headingClientWidth,
+  )
+  expect(metrics.documentScrollWidth).toBeLessThanOrEqual(
+    metrics.documentClientWidth,
+  )
+  expect(metrics.linkHeight).toBeGreaterThan(metrics.lineHeight * 1.5)
+})


### PR DESCRIPTION
## Why

Long API member names overflow the page on narrow screens instead of wrapping. The existing mobile wrapping rule never reaches those headings because it expects an `article` below `#nd-page`, while Fumadocs renders the `article` itself as `#nd-page`.

Fixes #4154.

## How

- Match headings below the actual `#nd-page` article so the existing `overflow-wrap: anywhere` rule applies.
- Add a Playwright regression test using the existing `CameraController` API page at a 393x852 viewport.
- Keep the test in a separate mobile-layout spec to avoid coupling it to screenshot baselines.

## Test plan

- `bun docs build`
- `bun docs types:check`
- `bun docs lint`
- `bun docs test:logic`
- `bun docs test:screenshots --grep 'long API member headings wrap on mobile'`

At 393x852, `convertWhiteBalanceTemperatureAndTintValues(...)` changes from `scrollWidth: 616px` in a `361px` heading to `scrollWidth: 361px` over two lines. The document remains 393px wide. At 1440x1200 the heading remains on one line (`800px` wide, no overflow).

The full screenshot run still reports the same three pre-existing local baseline mismatches for the landing page, hybrid-object page, and function page both before and after this change. The new mobile layout test passes and no snapshots are updated.
