### PR TITLE
fix: Use callback `setPreparedPhotoSettingsArray` overload to fix `EXC_BREAKPOINT` on cancel

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -818,14 +818,14 @@ describe('VisionCamera - Photo', () => {
       const firstPreparationRejection = expect(
         withTimeout(
           firstPreparation,
-          5_000,
+          10_000,
           'superseded Photo settings preparation',
         ),
       ).rejects.toThrow('Settings preparation has been canceled!')
-      const replacementPreparation = photoOutput.prepareSettings([])
+      const replacementPreparation = photoOutput.prepareSettings([{}])
 
-      await firstPreparationRejection
       await session.start()
+      await firstPreparationRejection
       await withTimeout(
         replacementPreparation,
         10_000,

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -803,15 +803,15 @@ describe('VisionCamera - Photo', () => {
       quality: 0.8,
       qualityPrioritization: 'balanced',
     })
-    await session.configure([
-      {
-        input: backDevice,
-        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
-        constraints: [],
-      },
-    ])
-
     try {
+      await session.configure([
+        {
+          input: backDevice,
+          outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+          constraints: [],
+        },
+      ])
+
       // iOS defers preparation while the session is stopped. Submitting a new
       // request must cancel the pending request without crashing the process.
       const firstPreparation = photoOutput.prepareSettings([{}])

--- a/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.photo.harness.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import {
   assert,
   beforeAll,
@@ -20,6 +21,7 @@ import type {
   Size,
 } from 'react-native-vision-camera'
 import { CommonResolutions, VisionCamera } from 'react-native-vision-camera'
+import { withTimeout } from './test-utils'
 
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => setTimeout(resolve, ms))
@@ -784,6 +786,51 @@ describe('VisionCamera - Photo', () => {
       expect(photo.width).toBeGreaterThan(0)
       expect(photo.height).toBeGreaterThan(0)
       photo.dispose()
+    } finally {
+      await session.stop()
+    }
+  })
+
+  it('rejects a superseded Photo settings preparation', async (context) => {
+    if (Platform.OS !== 'ios') {
+      return context.skip('Photo settings preparation cancellation: iOS only')
+    }
+
+    const session = await VisionCamera.createCameraSession(false)
+    const photoOutput = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.HD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    await session.configure([
+      {
+        input: backDevice,
+        outputs: [{ output: photoOutput, mirrorMode: 'auto' }],
+        constraints: [],
+      },
+    ])
+
+    try {
+      // iOS defers preparation while the session is stopped. Submitting a new
+      // request must cancel the pending request without crashing the process.
+      const firstPreparation = photoOutput.prepareSettings([{}])
+      const firstPreparationRejection = expect(
+        withTimeout(
+          firstPreparation,
+          5_000,
+          'superseded Photo settings preparation',
+        ),
+      ).rejects.toThrow('Settings preparation has been canceled!')
+      const replacementPreparation = photoOutput.prepareSettings([])
+
+      await firstPreparationRejection
+      await session.start()
+      await withTimeout(
+        replacementPreparation,
+        10_000,
+        'replacement Photo settings preparation',
+      )
     } finally {
       await session.stop()
     }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraPhotoOutput.swift
@@ -185,11 +185,21 @@ final class HybridCameraPhotoOutput: HybridCameraPhotoOutputSpec, NativeCameraOu
   }
 
   func prepareSettings(settings: [CapturePhotoSettings]) throws -> Promise<Void> {
-    return Promise.async {
-      let captureSettings = try settings.map {
-        try $0.toAVCapturePhotoSettings(for: self.output, withOptions: self.options)
-      }
-      try await self.output.setPreparedPhotoSettingsArray(captureSettings)
+    let promise = Promise<Void>()
+    let captureSettings = try settings.map {
+      try $0.toAVCapturePhotoSettings(for: self.output, withOptions: self.options)
     }
+    self.output.setPreparedPhotoSettingsArray(captureSettings) { prepared, error in
+      if let error {
+        promise.reject(withError: error)
+      } else {
+        if prepared {
+          promise.resolve()
+        } else {
+          promise.reject(withError: RuntimeError("Settings preparation has been canceled!"))
+        }
+      }
+    }
+    return promise
   }
 }


### PR DESCRIPTION
Apparently the async overload for `setPreparedPhotoSettingsArray` could trap when it force-unwraps an NSError because of its `NS_SWIFT_ASYNC_THROWS_ON_FALSE(1)` annotation - but per documentation, `prepared` can be false and error is apparently nil - which then traps. This fixes it by just treating `prepared == false` as a custom cancelation error.

- Fixes #4160