### PR TITLE
fix: Mark react-native-nitro-modules peer dependency as optional

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,9 @@
         "react-native-nitro-image": "*",
         "react-native-nitro-modules": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
     "packages/react-native-vision-camera-barcode-scanner": {
       "name": "react-native-vision-camera-barcode-scanner",
@@ -140,6 +143,9 @@
         "react-native-nitro-modules": "*",
         "react-native-vision-camera": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
     "packages/react-native-vision-camera-location": {
       "name": "react-native-vision-camera-location",
@@ -159,6 +165,9 @@
         "react-native-nitro-modules": "*",
         "react-native-vision-camera": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
     "packages/react-native-vision-camera-resizer": {
       "name": "react-native-vision-camera-resizer",
@@ -178,6 +187,9 @@
         "react-native-nitro-modules": "*",
         "react-native-vision-camera": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
     "packages/react-native-vision-camera-skia": {
       "name": "react-native-vision-camera-skia",
@@ -224,6 +236,9 @@
         "react-native-vision-camera": "*",
         "react-native-worklets": "*",
       },
+      "optionalPeers": [
+        "react-native-nitro-modules",
+      ],
     },
   },
   "trustedDependencies": [

--- a/packages/react-native-vision-camera-barcode-scanner/package.json
+++ b/packages/react-native-vision-camera-barcode-scanner/package.json
@@ -81,6 +81,11 @@
     "react-native-nitro-modules": "*",
     "react-native-vision-camera": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "release-it": {
     "npm": {
       "publish": true

--- a/packages/react-native-vision-camera-location/package.json
+++ b/packages/react-native-vision-camera-location/package.json
@@ -78,6 +78,11 @@
     "react-native-nitro-modules": "*",
     "react-native-vision-camera": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "release-it": {
     "npm": {
       "publish": true

--- a/packages/react-native-vision-camera-resizer/package.json
+++ b/packages/react-native-vision-camera-resizer/package.json
@@ -83,6 +83,11 @@
     "react-native-nitro-modules": "*",
     "react-native-vision-camera": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "release-it": {
     "npm": {
       "publish": true

--- a/packages/react-native-vision-camera-worklets/package.json
+++ b/packages/react-native-vision-camera-worklets/package.json
@@ -81,6 +81,11 @@
     "react-native-vision-camera": "*",
     "react-native-worklets": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "release-it": {
     "npm": {
       "publish": true

--- a/packages/react-native-vision-camera/package.json
+++ b/packages/react-native-vision-camera/package.json
@@ -83,6 +83,11 @@
     "react-native-nitro-modules": "*",
     "react-native-nitro-image": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-nitro-modules": {
+      "optional": true
+    }
+  },
   "release-it": {
     "npm": {
       "publish": true


### PR DESCRIPTION
## Problem

Semver ranges **never match pre-release versions** unless a comparator shares the same `major.minor.patch` tuple *and* carries a pre-release tag. So the `"react-native-nitro-modules": "*"` peer range does not match a version like `0.37.0-beta.0`:

| range | 0.36.5 | 0.37.0-beta.0 | 0.37.0 | 0.38.0-beta.0 |
|---|---|---|---|---|
| `*` | yes | **no** | yes | **no** |
| `>=0.0.0-0` | yes | **no** | yes | **no** |
| `>=0.37.0-0` | no | yes | yes | **no** |

Because the peer is *required*, bun satisfies it itself by installing a second, **stable** copy of `react-native-nitro-modules` nested inside this library. An app testing a Nitro pre-release then builds native against the pre-release while Metro bundles the stable JS, and Nitro throws at startup:

```
Nitro was installed twice: once with native version 0.37.0-beta.0 and once with JS version 0.36.5.
```

Builds stay green - only runtime catches it.

## Fix

Mark the peer optional, so the consuming app is the sole decider of the Nitro version. No range can express "anything, including future pre-releases" (`>=0.37.0-0` just moves the breakage to 0.38.0-beta.0), so this has to be resolution behaviour rather than a cleverer range.

```json
"peerDependenciesMeta": {
  "react-native-nitro-modules": { "optional": true }
}
```

Upstream fix in the Nitro template + docs: mrousavy/nitro#1516

## Trade-off

`optional: true` also suppresses the *missing* peer warning. Acceptable: a Nitro Module without `react-native-nitro-modules` fails loudly at build time (autolinking cannot find the pod / Gradle project), and version mismatches are caught by Nitro's runtime guard - strictly stronger than an install-time range check.

The example app declares `react-native-nitro-modules` directly, so it is unaffected.