### PR TITLE
fix: Memoize `targetResolution` in output hooks

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.hooks.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.hooks.harness.tsx
@@ -19,16 +19,21 @@ import type {
   CameraDevice,
   CameraDeviceFactory,
   CameraOrientation,
+  CameraPhotoOutput,
   CameraPosition,
+  CameraVideoOutput,
   DeviceFilter,
   TargetCameraPosition,
 } from 'react-native-vision-camera'
 import {
+  CommonResolutions,
   getUIRotation,
   useCamera,
   useCameraDevice,
   useOrientation,
+  usePhotoOutput,
   usePreviewOutput,
+  useVideoOutput,
   VisionCamera,
 } from 'react-native-vision-camera'
 
@@ -338,6 +343,129 @@ describe('VisionCamera - Hooks', () => {
     } finally {
       await rerender(<TestCamera screenOrientation="portrait_up" />)
     }
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('keeps outputs stable when targetResolution is passed as an inline object literal', async () => {
+    const onConfigured = fn<() => void>()
+    const onError = fn<(error: Error) => void>()
+    const onRendered =
+      fn<
+        (
+          renderIndex: number,
+          photoOutput: CameraPhotoOutput,
+          videoOutput: CameraVideoOutput,
+        ) => void
+      >()
+
+    function TestCamera({
+      renderIndex,
+      width,
+      height,
+    }: {
+      renderIndex: number
+      width: number
+      height: number
+    }): null {
+      // CameraX requires at least one use case when configuring a session.
+      const previewOutput = usePreviewOutput()
+      // Both `targetResolution`s are inline object literals, so they have a
+      // fresh identity on every single render even though their values never
+      // change. They must not re-create the outputs.
+      const photoOutput = usePhotoOutput({
+        targetResolution: { width: width, height: height },
+      })
+      const videoOutput = useVideoOutput({
+        targetResolution: { width: width, height: height },
+        enableAudio: false,
+      })
+      useCamera({
+        isActive: false,
+        device: 'back',
+        outputs: [previewOutput, photoOutput, videoOutput],
+        onConfigured,
+        onError,
+      })
+
+      useEffect(() => {
+        onRendered(renderIndex, photoOutput, videoOutput)
+      }, [renderIndex, photoOutput, videoOutput])
+
+      return null
+    }
+
+    const waitForRender = async (renderIndex: number): Promise<void> => {
+      await waitFor(
+        () => {
+          const error = onError.mock.lastCall?.[0]
+          if (error != null) throw error
+          expect(onRendered.mock.lastCall?.[0]).toBe(renderIndex)
+        },
+        { timeout: 10_000 },
+      )
+    }
+
+    const stableResolution = CommonResolutions.HD_4_3
+    const changedResolution = CommonResolutions.VGA_4_3
+
+    const { rerender } = await render(
+      <TestCamera
+        renderIndex={0}
+        width={stableResolution.width}
+        height={stableResolution.height}
+      />,
+      { timeout: 10_000 },
+    )
+    await waitForRender(0)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 15_000 },
+    )
+
+    const initialPhotoOutput = onRendered.mock.lastCall?.[1]
+    const initialVideoOutput = onRendered.mock.lastCall?.[2]
+    expect(initialPhotoOutput).toBeDefined()
+    expect(initialVideoOutput).toBeDefined()
+
+    // Re-rendering with the same resolution values must reuse the same outputs.
+    for (const renderIndex of [1, 2, 3]) {
+      await rerender(
+        <TestCamera
+          renderIndex={renderIndex}
+          width={stableResolution.width}
+          height={stableResolution.height}
+        />,
+      )
+      await waitForRender(renderIndex)
+      expect(onRendered.mock.lastCall?.[1]).toBe(initialPhotoOutput)
+      expect(onRendered.mock.lastCall?.[2]).toBe(initialVideoOutput)
+    }
+
+    // Changing the actual resolution values must re-create the outputs and
+    // re-configure the session exactly once more.
+    await rerender(
+      <TestCamera
+        renderIndex={4}
+        width={changedResolution.width}
+        height={changedResolution.height}
+      />,
+    )
+    await waitForRender(4)
+    expect(onRendered.mock.lastCall?.[1]).not.toBe(initialPhotoOutput)
+    expect(onRendered.mock.lastCall?.[2]).not.toBe(initialVideoOutput)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(2)
+      },
+      { timeout: 15_000 },
+    )
 
     expect(onError).not.toHaveBeenCalled()
   })

--- a/packages/react-native-vision-camera/src/hooks/internal/useMemoizedSize.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useMemoizedSize.ts
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import type { Size } from '../../specs/common-types/Size'
+import type { CameraOutput } from '../../specs/outputs/CameraOutput.nitro'
+import type { CameraSession } from '../../specs/session/CameraSession.nitro'
+
+/**
+ * Memoizes the given {@linkcode Size} by value instead of by identity.
+ *
+ * {@linkcode Size}s are usually written as inline object literals
+ * (e.g. `useVideoOutput({ targetResolution: { width: 1920, height: 1080 } })`),
+ * which allocates a new object on every render. Using such a {@linkcode Size}
+ * as a `useMemo` dependency would re-create the {@linkcode CameraOutput} on
+ * every render, and re-creating an output re-configures the
+ * {@linkcode CameraSession} - which renders again, which re-creates the
+ * output again, and so on.
+ */
+export function useMemoizedSize(size: Size): Size
+export function useMemoizedSize(size: Size | undefined): Size | undefined
+export function useMemoizedSize(size: Size | undefined): Size | undefined {
+  const width = size?.width
+  const height = size?.height
+
+  return useMemo(() => {
+    if (width == null || height == null) return undefined
+    return { width: width, height: height }
+  }, [width, height])
+}

--- a/packages/react-native-vision-camera/src/hooks/useDepthOutput.ts
+++ b/packages/react-native-vision-camera/src/hooks/useDepthOutput.ts
@@ -8,6 +8,7 @@ import type {
 import { VisionCameraWorkletsProxy } from '../third-party/VisionCameraWorkletsProxy'
 import { CommonResolutions } from '../utils/CommonResolutions'
 import { VisionCamera } from '../VisionCamera'
+import { useMemoizedSize } from './internal/useMemoizedSize'
 
 type BaseDepthOptions = Pick<
   DepthFrameOutputOptions,
@@ -75,25 +76,28 @@ export function useDepthOutput({
   dropFramesWhileBusy = true,
   allowDeferredStart = true,
 }: UseDepthOutputProps): CameraDepthFrameOutput {
-  // 1. Create depth output
+  // 1. `targetResolution` is usually an inline object literal - memoize it by value.
+  const memoizedTargetResolution = useMemoizedSize(targetResolution)
+
+  // 2. Create depth output
   const depthOutput = useMemo(
     () =>
       VisionCamera.createDepthFrameOutput({
-        targetResolution: targetResolution,
+        targetResolution: memoizedTargetResolution,
         enableFiltering: enableFiltering,
         enablePhysicalBufferRotation: false,
         dropFramesWhileBusy: dropFramesWhileBusy,
         allowDeferredStart: allowDeferredStart,
       }),
     [
-      targetResolution,
+      memoizedTargetResolution,
       enableFiltering,
       dropFramesWhileBusy,
       allowDeferredStart,
     ],
   )
 
-  // 2. Add Frame dropped warner
+  // 3. Add Frame dropped warner
   const onDepthFrameDroppedRef = useRef(onDepthFrameDropped)
   onDepthFrameDroppedRef.current = onDepthFrameDropped
   useEffect(() => {
@@ -104,16 +108,16 @@ export function useDepthOutput({
     })
   }, [depthOutput])
 
-  // 3. Create Worklet Runtime for NativeThread
+  // 4. Create Worklet Runtime for NativeThread
   const runtime = useMemo(
     () => VisionCameraWorkletsProxy.createRuntimeForThread(depthOutput.thread),
     [depthOutput.thread],
   )
-  // 4. Update onDepth() callback if it changed
+  // 5. Update onDepth() callback if it changed
   useEffect(() => {
     runtime.setOnDepthFrameCallback(depthOutput, onDepth)
   }, [runtime, depthOutput, onDepth])
 
-  // 5. Return :)
+  // 6. Return :)
   return depthOutput
 }

--- a/packages/react-native-vision-camera/src/hooks/useFrameOutput.ts
+++ b/packages/react-native-vision-camera/src/hooks/useFrameOutput.ts
@@ -14,6 +14,7 @@ import type {
 import { VisionCameraWorkletsProxy } from '../third-party/VisionCameraWorkletsProxy'
 import { CommonResolutions } from '../utils/CommonResolutions'
 import { VisionCamera } from '../VisionCamera'
+import { useMemoizedSize } from './internal/useMemoizedSize'
 
 export interface UseFrameOutputProps extends Partial<FrameOutputOptions> {
   /**
@@ -129,11 +130,14 @@ export function useFrameOutput({
   onFrame,
   onFrameDropped,
 }: UseFrameOutputProps): CameraFrameOutput {
-  // 1. Create frame output
+  // 1. `targetResolution` is usually an inline object literal - memoize it by value.
+  const memoizedTargetResolution = useMemoizedSize(targetResolution)
+
+  // 2. Create frame output
   const frameOutput = useMemo(
     () =>
       VisionCamera.createFrameOutput({
-        targetResolution: targetResolution,
+        targetResolution: memoizedTargetResolution,
         pixelFormat: pixelFormat,
         enablePhysicalBufferRotation: enablePhysicalBufferRotation,
         enableCameraMatrixDelivery: enableCameraMatrixDelivery,
@@ -142,7 +146,7 @@ export function useFrameOutput({
         dropFramesWhileBusy: dropFramesWhileBusy,
       }),
     [
-      targetResolution,
+      memoizedTargetResolution,
       pixelFormat,
       dropFramesWhileBusy,
       enableCameraMatrixDelivery,
@@ -152,7 +156,7 @@ export function useFrameOutput({
     ],
   )
 
-  // 2. Add Frame dropped warner
+  // 3. Add Frame dropped warner
   const onFrameDroppedRef = useRef(onFrameDropped)
   onFrameDroppedRef.current = onFrameDropped
   useEffect(() => {
@@ -163,16 +167,16 @@ export function useFrameOutput({
     })
   }, [frameOutput])
 
-  // 3. Create Worklet Runtime for NativeThread
+  // 4. Create Worklet Runtime for NativeThread
   const runtime = useMemo(
     () => VisionCameraWorkletsProxy.createRuntimeForThread(frameOutput.thread),
     [frameOutput.thread],
   )
-  // 4. Update onFrame() callback if it changed
+  // 5. Update onFrame() callback if it changed
   useEffect(() => {
     runtime.setOnFrameCallback(frameOutput, onFrame)
   }, [runtime, frameOutput, onFrame])
 
-  // 5. Return :)
+  // 6. Return :)
   return frameOutput
 }

--- a/packages/react-native-vision-camera/src/hooks/usePhotoOutput.ts
+++ b/packages/react-native-vision-camera/src/hooks/usePhotoOutput.ts
@@ -7,6 +7,7 @@ import type {
 import { CommonResolutions } from '../utils/CommonResolutions'
 import { VisionCamera } from '../VisionCamera'
 import type { Camera } from '../views/Camera'
+import { useMemoizedSize } from './internal/useMemoizedSize'
 
 /**
  * Use a {@linkcode CameraPhotoOutput} for capturing {@linkcode Photo}s.
@@ -35,22 +36,26 @@ export function usePhotoOutput({
   qualityPrioritization = 'balanced',
   previewImageTargetSize = undefined,
 }: Partial<PhotoOutputOptions> = {}): CameraPhotoOutput {
-  // 1. Create photo output
+  // 1. `Size`s are usually inline object literals - memoize them by value.
+  const memoizedTargetResolution = useMemoizedSize(targetResolution)
+  const memoizedPreviewImageTargetSize = useMemoizedSize(previewImageTargetSize)
+
+  // 2. Create photo output
   const photoOutput = useMemo(
     () =>
       VisionCamera.createPhotoOutput({
-        targetResolution: targetResolution,
+        targetResolution: memoizedTargetResolution,
         containerFormat: containerFormat,
         quality: quality,
         qualityPrioritization: qualityPrioritization,
-        previewImageTargetSize: previewImageTargetSize,
+        previewImageTargetSize: memoizedPreviewImageTargetSize,
       }),
     [
-      targetResolution,
+      memoizedTargetResolution,
       containerFormat,
       quality,
       qualityPrioritization,
-      previewImageTargetSize,
+      memoizedPreviewImageTargetSize,
     ],
   )
 

--- a/packages/react-native-vision-camera/src/hooks/useVideoOutput.ts
+++ b/packages/react-native-vision-camera/src/hooks/useVideoOutput.ts
@@ -7,6 +7,7 @@ import type { Recorder } from '../specs/outputs/Recorder.nitro'
 import { CommonResolutions } from '../utils/CommonResolutions'
 import { VisionCamera } from '../VisionCamera'
 import type { Camera } from '../views/Camera'
+import { useMemoizedSize } from './internal/useMemoizedSize'
 
 /**
  * Use a {@linkcode CameraVideoOutput} for recording videos.
@@ -42,10 +43,13 @@ export function useVideoOutput({
   enableAudio,
   fileType,
 }: Partial<VideoOutputOptions> = {}): CameraVideoOutput {
+  // `targetResolution` is usually an inline object literal - memoize it by value.
+  const memoizedTargetResolution = useMemoizedSize(targetResolution)
+
   const videoOutput = useMemo(
     () =>
       VisionCamera.createVideoOutput({
-        targetResolution: targetResolution,
+        targetResolution: memoizedTargetResolution,
         targetBitRate: targetBitRate,
         enablePersistentRecorder: enablePersistentRecorder,
         enableAudio: enableAudio,
@@ -55,7 +59,7 @@ export function useVideoOutput({
       enablePersistentRecorder,
       targetBitRate,
       enableAudio,
-      targetResolution,
+      memoizedTargetResolution,
       fileType,
     ],
   )


### PR DESCRIPTION
## What

`targetResolution` (and `previewImageTargetSize`) are `Size` objects, and users almost always write them as inline object literals:

```tsx
const photoOutput = usePhotoOutput({
  targetResolution: { width: 1920, height: 1080 },
})
```

An inline literal gets a fresh identity on every render, so the `useMemo(...)` inside `usePhotoOutput` / `useVideoOutput` / `useFrameOutput` / `useDepthOutput` misses its cache and creates a **brand new `CameraOutput` on every render**.

That isn't just wasteful, it self-perpetuates:

1. New output -> the `outputs` array changes
2. -> `useCameraController`'s effect re-runs and re-configures the `CameraSession`
3. -> `setController(...)` -> re-render
4. -> back to 1.

The session ends up in an endless reconfigure loop and takes the app down within seconds.

## How

Adds an internal `useMemoizedSize(...)` hook that memoizes a `Size` by its `width`/`height` values instead of by object identity, and uses it in all four output hooks. Outputs are now only re-created when the requested resolution actually changes.

This also covers `<SkiaCamera targetResolution={...} />`, which forwards straight into `useFrameOutput(...)`.

## Test

Adds a Harness test in `visioncamera.hooks.harness.tsx` that:

- renders a component whose `targetResolution`s are inline object literals,
- re-renders it three times with the same values, asserting the `CameraPhotoOutput` / `CameraVideoOutput` keep their identity and that `onConfigured` fired exactly **once**,
- then re-renders with different resolution values and asserts the outputs *are* re-created and the session is re-configured exactly once more.

Without the fix the identity assertions fail on the first re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)