### PR TITLE
fix: Deep-compare `constraints` instead of `JSON.stringify`-ing them

### DIFF
--- a/apps/simple-camera/__tests__/visioncamera.hooks.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.hooks.harness.tsx
@@ -469,4 +469,178 @@ describe('VisionCamera - Hooks', () => {
 
     expect(onError).not.toHaveBeenCalled()
   })
+
+  it('does not re-configure the session when constraints are passed as an inline array', async () => {
+    const onConfigured = fn<() => void>()
+    const onError = fn<(error: Error) => void>()
+    const onRendered = fn<(renderIndex: number) => void>()
+
+    function TestCamera({
+      renderIndex,
+      fps,
+    }: {
+      renderIndex: number
+      fps: number
+    }): null {
+      // CameraX requires at least one use case when configuring a session.
+      const previewOutput = usePreviewOutput()
+      useCamera({
+        isActive: false,
+        device: 'back',
+        outputs: [previewOutput],
+        // An inline array of inline object literals, so `constraints` has a
+        // fresh identity on every single render even though its values never
+        // change. It must not re-configure the session.
+        constraints: [{ fps: fps }],
+        onConfigured,
+        onError,
+      })
+
+      useEffect(() => {
+        onRendered(renderIndex)
+      }, [renderIndex])
+
+      return null
+    }
+
+    const waitForRender = async (renderIndex: number): Promise<void> => {
+      await waitFor(
+        () => {
+          const error = onError.mock.lastCall?.[0]
+          if (error != null) throw error
+          expect(onRendered).toHaveBeenLastCalledWith(renderIndex)
+        },
+        { timeout: 10_000 },
+      )
+    }
+
+    const { rerender } = await render(<TestCamera renderIndex={0} fps={30} />, {
+      timeout: 10_000,
+    })
+    await waitForRender(0)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 15_000 },
+    )
+
+    // Re-rendering with the same constraint values must not re-configure.
+    for (const renderIndex of [1, 2, 3]) {
+      await rerender(<TestCamera renderIndex={renderIndex} fps={30} />)
+      await waitForRender(renderIndex)
+      expect(onConfigured).toHaveBeenCalledTimes(1)
+    }
+
+    // Changing the actual constraint values must re-configure exactly once more.
+    await rerender(<TestCamera renderIndex={4} fps={24} />)
+    await waitForRender(4)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(2)
+      },
+      { timeout: 15_000 },
+    )
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('re-configures the session when a resolutionBias constraint points at a different output', async () => {
+    // Two outputs of the same HybridObject type. They are only used as
+    // resolution hints, so the attached `outputs` stay identical across every
+    // re-render and the `constraints` are the only thing that changes.
+    const lowResolutionBias = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.VGA_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const highResolutionBias = VisionCamera.createPhotoOutput({
+      targetResolution: CommonResolutions.UHD_4_3,
+      containerFormat: 'jpeg',
+      quality: 0.8,
+      qualityPrioritization: 'balanced',
+    })
+    const onConfigured = fn<() => void>()
+    const onError = fn<(error: Error) => void>()
+    const onRendered = fn<(renderIndex: number) => void>()
+
+    function TestCamera({
+      renderIndex,
+      resolutionBias,
+    }: {
+      renderIndex: number
+      resolutionBias: CameraPhotoOutput
+    }): null {
+      // CameraX requires at least one use case when configuring a session.
+      const previewOutput = usePreviewOutput()
+      useCamera({
+        isActive: false,
+        device: 'back',
+        outputs: [previewOutput],
+        constraints: [{ resolutionBias: resolutionBias }],
+        onConfigured,
+        onError,
+      })
+
+      useEffect(() => {
+        onRendered(renderIndex)
+      }, [renderIndex])
+
+      return null
+    }
+
+    const waitForRender = async (renderIndex: number): Promise<void> => {
+      await waitFor(
+        () => {
+          const error = onError.mock.lastCall?.[0]
+          if (error != null) throw error
+          expect(onRendered).toHaveBeenLastCalledWith(renderIndex)
+        },
+        { timeout: 10_000 },
+      )
+    }
+
+    const { rerender } = await render(
+      <TestCamera renderIndex={0} resolutionBias={lowResolutionBias} />,
+      { timeout: 10_000 },
+    )
+    await waitForRender(0)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 15_000 },
+    )
+
+    // Re-rendering with the same output must not re-configure.
+    await rerender(
+      <TestCamera renderIndex={1} resolutionBias={lowResolutionBias} />,
+    )
+    await waitForRender(1)
+    expect(onConfigured).toHaveBeenCalledTimes(1)
+
+    // Pointing the bias at a different output must re-configure exactly once
+    // more, even though both outputs are the same HybridObject type.
+    await rerender(
+      <TestCamera renderIndex={2} resolutionBias={highResolutionBias} />,
+    )
+    await waitForRender(2)
+    await waitFor(
+      () => {
+        const error = onError.mock.lastCall?.[0]
+        if (error != null) throw error
+        expect(onConfigured).toHaveBeenCalledTimes(2)
+      },
+      { timeout: 15_000 },
+    )
+
+    expect(onError).not.toHaveBeenCalled()
+  })
 })

--- a/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useCameraController.ts
@@ -9,6 +9,7 @@ import type { CameraSession } from '../../specs/session/CameraSession.nitro'
 import type { CameraSessionConfig } from '../../specs/session/CameraSessionConfig.nitro'
 import type { CameraSessionConfiguration } from '../../specs/session/CameraSessionConfiguration'
 import { useMemoizedArray } from './useMemoizedArray'
+import { useMemoizedConstraints } from './useMemoizedConstraints'
 import { useStableCallback } from './useStableCallback'
 
 interface Config extends CameraSessionConfiguration {
@@ -61,14 +62,13 @@ export function useCameraController(
   )
   const stableOnError = useStableCallback(onError)
 
-  // TODO: Can we use something like useSyncExternalStore or whatever to avoid "wrong" dependencies?
-  // biome-ignore lint/correctness/useExhaustiveDependencies: It's an array of objects, we either have to deep-memo or just stringify.
+  const stableUserConstraints = useMemoizedConstraints(constraints)
   const stableConstraints = useMemo<Constraint[]>(() => {
     return [
-      ...constraints,
+      ...stableUserConstraints,
       ...stableOutputs.map<Constraint>((o) => ({ resolutionBias: o })),
     ]
-  }, [JSON.stringify(constraints), stableOutputs])
+  }, [stableUserConstraints, stableOutputs])
 
   // This effect re-configures the CameraSession and returns a `controller`.
   // This is expensive and should only be done if any inputs change.

--- a/packages/react-native-vision-camera/src/hooks/internal/useMemoizedConstraints.ts
+++ b/packages/react-native-vision-camera/src/hooks/internal/useMemoizedConstraints.ts
@@ -1,0 +1,67 @@
+import { useRef } from 'react'
+import type {
+  Constraint,
+  ResolutionBiasConstraint,
+} from '../../specs/common-types/Constraint'
+import type { CameraOutput } from '../../specs/outputs/CameraOutput.nitro'
+import type { CameraSession } from '../../specs/session/CameraSession.nitro'
+
+/**
+ * Returns whether the given {@linkcode value} is a plain JS object
+ * (i.e. an object literal like `{ fps: 60 }`), and not a class instance,
+ * an `Array`, or a Nitro `HybridObject`.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/**
+ * Deep-compares two {@linkcode Constraint} values.
+ *
+ * Object literals (e.g. `{ fps: 60 }`, or a `TargetDynamicRange`) and
+ * `Array`s are compared by value, everything else - most importantly the
+ * {@linkcode CameraOutput} of a {@linkcode ResolutionBiasConstraint} - is
+ * compared by identity.
+ *
+ * Nitro `HybridObject`s cannot be compared by value at all; they are created
+ * via `Object.create(prototype)` and hold every property on their shared
+ * prototype, so the actual JS object has no own keys (which is also why
+ * `JSON.stringify(...)` serializes every `CameraOutput` to the exact same
+ * string).
+ */
+function isEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false
+    if (left.length !== right.length) return false
+    return left.every((item, index) => isEqual(item, right[index]))
+  }
+
+  if (!isPlainObject(left) || !isPlainObject(right)) return false
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) return false
+  return leftKeys.every((key) => key in right && isEqual(left[key], right[key]))
+}
+
+/**
+ * Memoizes the given {@linkcode Constraint}s by value instead of by identity.
+ *
+ * {@linkcode Constraint}s are usually written as an inline array of object
+ * literals (e.g. `constraints={[{ fps: 60 }]}`), which allocates a new array
+ * and new objects on every render. Using those as a `useEffect` dependency
+ * would re-configure the {@linkcode CameraSession} on every single render,
+ * which renders again, and so on.
+ */
+export function useMemoizedConstraints(
+  constraints: Constraint[],
+): Constraint[] {
+  const memoized = useRef(constraints)
+  if (!isEqual(memoized.current, constraints)) {
+    memoized.current = constraints
+  }
+  return memoized.current
+}


### PR DESCRIPTION
## What

`useCameraController` kept the user's `constraints` stable by putting `JSON.stringify(constraints)` into the `useMemo` dependency array:

```ts
// biome-ignore lint/correctness/useExhaustiveDependencies: It's an array of objects, we either have to deep-memo or just stringify.
const stableConstraints = useMemo<Constraint[]>(() => { ... }, [JSON.stringify(constraints), stableOutputs])
```

That works for plain constraints like `{ fps: 60 }`, but it silently breaks for `{ resolutionBias: someOutput }`.

Nitro `HybridObject`s are created via `Object.create(prototype)` and hold every property on their shared prototype, so the JS object itself has **no own keys**. `JSON.stringify(...)` therefore serializes *every* `CameraOutput` to the same string:

| build | `JSON.stringify(photoOutput)` |
|---|---|
| release | `{}` |
| debug | `{"__type":"HybridObject<CameraPhotoOutput>"}` |

Two different outputs of the same type are indistinguishable. So this, which is the documented way to express capture priority:

```tsx
constraints={photoFirst
  ? [{ resolutionBias: photoOutput }, { resolutionBias: videoOutput }]
  : [{ resolutionBias: videoOutput }, { resolutionBias: photoOutput }]}
```

is invisible to the memo in release builds, and the session is never re-configured.

## How

Replaces the stringification with an explicit deep comparison (`useMemoizedConstraints(...)`) that compares object literals and arrays by value, and everything else (i.e. `HybridObject`s) by identity. It also drops a full JSON serialization from every render, and lets the `useMemo` dependency array be honest again (the `biome-ignore` is gone).

## Test

Adds two Harness tests in `visioncamera.hooks.harness.tsx`:

1. re-renders a component with an inline `constraints={[{ fps }]}` array and asserts `onConfigured` fired exactly **once**, then asserts changing the actual `fps` value re-configures exactly once more.
2. re-points a `resolutionBias` constraint at a *different* `CameraPhotoOutput` while the attached `outputs` stay identical, and asserts the session re-configures. Both bias outputs are deliberately the same HybridObject type, which is exactly what `JSON.stringify(...)` could not tell apart - this test is red on `main`.

## Note

Touches the same import block in `visioncamera.hooks.harness.tsx` as #4166, so whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)