### PR TITLE
feat: Add native tap-to-focus reset listener

### DIFF
--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/HybridCameraController.kt
@@ -2,6 +2,9 @@ package com.margelo.nitro.camera.hybrids
 
 import android.animation.Animator
 import android.animation.ValueAnimator
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import androidx.camera.core.Camera
 import androidx.camera.core.CameraState
 import androidx.camera.core.FocusMeteringAction
@@ -33,6 +36,7 @@ import com.margelo.nitro.core.Promise
 import com.margelo.nitro.core.resolve
 import com.margelo.nitro.core.resolved
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 class HybridCameraController(
   val camera: Camera,
@@ -41,6 +45,10 @@ class HybridCameraController(
   private val cameraState: CameraState?
     get() = camera.cameraInfo.cameraState.value
   private var zoomAnimator: ValueAnimator? = null
+  private val focusResetHandler = Handler(Looper.getMainLooper())
+  private val focusGeneration = AtomicLong()
+  private val focusResetLock = Any()
+  private var pendingFocusReset: Runnable? = null
 
   override val isConnected: Boolean
     get() = cameraState?.type == CameraState.Type.OPEN
@@ -140,7 +148,14 @@ class HybridCameraController(
   override fun focusTo(
     point: HybridMeteringPointSpec,
     options: FocusOptions,
+  ): Promise<Unit> = focusTo(point, options, null)
+
+  fun focusTo(
+    point: HybridMeteringPointSpec,
+    options: FocusOptions,
+    onReset: (() -> Unit)?,
   ): Promise<Unit> {
+    val generation = beginFocusOperation()
     return Promise.async {
       val point =
         point as? HybridMeteringPoint
@@ -159,14 +174,68 @@ class HybridCameraController(
             SceneAdaptiveness.CONTINUOUS -> action.setLockingMode(0)
           }
           // Disable auto reset, or set it to a fixed duration (seconds)
-          autoResetAfter.match(
-            { _ -> action.disableAutoCancel() },
-            { duration -> action.setAutoCancelDuration(duration.toLong(), TimeUnit.SECONDS) },
-          )
+          if (onReset != null) {
+            action.disableAutoCancel()
+          } else {
+            autoResetAfter.match(
+              { _ -> action.disableAutoCancel() },
+              { duration -> action.setAutoCancelDuration(duration.toLong(), TimeUnit.SECONDS) },
+            )
+          }
         }
       camera.cameraControl
         .startFocusAndMetering(focusAction.build())
         .await()
+
+      if (onReset != null) {
+        autoResetAfter.match(
+          { _ -> },
+          { duration -> scheduleFocusReset(generation, duration, onReset) },
+        )
+      }
+    }
+  }
+
+  private fun beginFocusOperation(): Long {
+    val generation = focusGeneration.incrementAndGet()
+    synchronized(focusResetLock) {
+      pendingFocusReset?.let { focusResetHandler.removeCallbacks(it) }
+      pendingFocusReset = null
+    }
+    return generation
+  }
+
+  private fun scheduleFocusReset(
+    generation: Long,
+    duration: Double,
+    onReset: () -> Unit,
+  ) {
+    val reset =
+      Runnable {
+        if (focusGeneration.get() != generation) return@Runnable
+        val future = camera.cameraControl.cancelFocusAndMetering()
+        future.addListener(
+          {
+            try {
+              future.get()
+              if (focusGeneration.get() == generation) {
+                synchronized(focusResetLock) {
+                  pendingFocusReset = null
+                }
+                onReset()
+              }
+            } catch (error: Throwable) {
+              Log.e(TAG, "Failed to automatically reset focus!", error)
+            }
+          },
+          { command -> focusResetHandler.post(command) },
+        )
+      }
+    synchronized(focusResetLock) {
+      if (focusGeneration.get() == generation) {
+        pendingFocusReset = reset
+        focusResetHandler.postDelayed(reset, (duration * 1_000).toLong())
+      }
     }
   }
 
@@ -183,6 +252,7 @@ class HybridCameraController(
   }
 
   override fun resetFocus(): Promise<Unit> {
+    beginFocusOperation()
     return Promise.async {
       camera.cameraControl
         .cancelFocusAndMetering()

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/gestures/HybridTapToFocusGestureController.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/hybrids/gestures/HybridTapToFocusGestureController.kt
@@ -28,6 +28,7 @@ class HybridTapToFocusGestureController :
   private var previewView: PreviewView? = null
   private val onTapListeners = mutableSetOf<(HybridMeteringPointSpec) -> Unit>()
   private val onFocusCompletedListeners = mutableSetOf<(HybridMeteringPointSpec) -> Unit>()
+  private val onFocusResetListeners = mutableSetOf<(HybridMeteringPointSpec) -> Unit>()
   private val context: Context
     get() = NitroModules.applicationContext ?: throw Error("Context not available!")
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -50,8 +51,18 @@ class HybridTapToFocusGestureController :
           val density = context.resources.displayMetrics.density
           val meteringPoint = HybridMeteringPoint((e.x / density).toDouble(), (e.y / density).toDouble(), null, point)
           onTapListeners.toList().forEach { it(meteringPoint) }
-          controller
-            .focusTo(meteringPoint, FocusOptions(null, null, null, null))
+          val focusOptions = FocusOptions(null, null, null, null)
+          val focusPromise =
+            if (controller is HybridCameraController) {
+              controller.focusTo(meteringPoint, focusOptions) {
+                mainHandler.post {
+                  onFocusResetListeners.toList().forEach { it(meteringPoint) }
+                }
+              }
+            } else {
+              controller.focusTo(meteringPoint, focusOptions)
+            }
+          focusPromise
             .then {
               mainHandler.post {
                 onFocusCompletedListeners.toList().forEach { it(meteringPoint) }
@@ -120,6 +131,13 @@ class HybridTapToFocusGestureController :
     onFocusCompletedListeners.add(onFocusCompleted)
     return ListenerSubscription {
       onFocusCompletedListeners.remove(onFocusCompleted)
+    }
+  }
+
+  override fun addOnFocusResetListener(onFocusReset: (HybridMeteringPointSpec) -> Unit): ListenerSubscription {
+    onFocusResetListeners.add(onFocusReset)
+    return ListenerSubscription {
+      onFocusResetListeners.remove(onFocusReset)
     }
   }
 }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Gestures/HybridTapToFocusGestureController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Gestures/HybridTapToFocusGestureController.swift
@@ -18,6 +18,7 @@ final class HybridTapToFocusGestureController: HybridTapToFocusGestureController
   private weak var previewView: (any HybridPreviewViewSpec)? = nil
   private var onTapListeners: [UUID: (any HybridMeteringPointSpec) -> Void] = [:]
   private var onFocusCompletedListeners: [UUID: (any HybridMeteringPointSpec) -> Void] = [:]
+  private var onFocusResetListeners: [UUID: (any HybridMeteringPointSpec) -> Void] = [:]
 
   override init() {
     super.init()
@@ -39,7 +40,24 @@ final class HybridTapToFocusGestureController: HybridTapToFocusGestureController
       let tapListeners = Array(onTapListeners.values)
       tapListeners.forEach { $0(meteringPoint) }
 
-      try controller.focusTo(point: meteringPoint, options: FocusOptions())
+      let onReset = { [weak self] in
+        DispatchQueue.main.async { [weak self] in
+          guard let self else { return }
+          let focusResetListeners = Array(self.onFocusResetListeners.values)
+          focusResetListeners.forEach { $0(meteringPoint) }
+        }
+      }
+      let focusPromise: Promise<Void>
+      if let nativeController = controller as? HybridCameraController {
+        focusPromise = nativeController.focusTo(
+          point: meteringPoint,
+          options: FocusOptions(),
+          onReset: onReset)
+      } else {
+        focusPromise = try controller.focusTo(point: meteringPoint, options: FocusOptions())
+      }
+
+      focusPromise
         .then { [weak self] _ in
           DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -72,6 +90,16 @@ final class HybridTapToFocusGestureController: HybridTapToFocusGestureController
     onFocusCompletedListeners[id] = onFocusCompleted
     return ListenerSubscription { [weak self] in
       self?.onFocusCompletedListeners.removeValue(forKey: id)
+    }
+  }
+
+  func addOnFocusResetListener(onFocusReset: @escaping (any HybridMeteringPointSpec) -> Void)
+    -> ListenerSubscription
+  {
+    let id = UUID()
+    onFocusResetListeners[id] = onFocusReset
+    return ListenerSubscription { [weak self] in
+      self?.onFocusResetListeners.removeValue(forKey: id)
     }
   }
 

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/HybridCameraController.swift
@@ -172,6 +172,14 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
     point: any HybridMeteringPointSpec,
     options: FocusOptions
   ) -> Promise<Void> {
+    return focusTo(point: point, options: options, onReset: nil)
+  }
+
+  func focusTo(
+    point: any HybridMeteringPointSpec,
+    options: FocusOptions,
+    onReset: (() -> Void)?
+  ) -> Promise<Void> {
     return captureDevice.withLock(queue) { resolve, reject in
       guard let point = point as? HybridMeteringPoint else {
         throw RuntimeError.error(withMessage: "MeteringPoint is not of type `HybridMeteringPoint`!")
@@ -214,7 +222,8 @@ final class HybridCameraController: HybridCameraControllerSpec, NativeCameraCont
       // Start listening to updates
       task.startListening(
         onComplete: resolve,
-        onError: reject
+        onError: reject,
+        onReset: onReset
       )
       self.activeMeteringTask = task
 

--- a/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
+++ b/packages/react-native-vision-camera/ios/Utils/MeteringTask.swift
@@ -42,6 +42,7 @@ final class MeteringTask {
   private var isFinished = false
   private var onComplete: (() -> Void)? = nil
   private var onError: ((Error) -> Void)? = nil
+  private var onReset: (() -> Void)? = nil
 
   private struct MeteringProgress {
     var settledAt: Date? = nil
@@ -87,10 +88,12 @@ final class MeteringTask {
    */
   func startListening(
     onComplete: @escaping () -> Void,
-    onError: @escaping (Error) -> Void
+    onError: @escaping (Error) -> Void,
+    onReset: (() -> Void)?
   ) {
     self.onComplete = onComplete
     self.onError = onError
+    self.onReset = onReset
     // the Timer periodically polls AE/AF/AWB state - this is how we can ensure the states have
     // been stable for 120ms+ and aren't just fluctuating.
     let pollTimer = DispatchSource.makeTimerSource(queue: queue)
@@ -171,7 +174,14 @@ final class MeteringTask {
       if case .after(let seconds) = self.autoReset {
         self.queue.asyncAfter(deadline: .now() + seconds) { [weak self] in
           guard let self else { return }
-          try? self.resetMeteringValues()
+          do {
+            try self.resetMeteringValues()
+            let onReset = self.onReset
+            self.onReset = nil
+            onReset?()
+          } catch {
+            logger.error("Failed to automatically reset metering! \(error)")
+          }
         }
       }
     }

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridTapToFocusGestureControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridTapToFocusGestureControllerSpec.cpp
@@ -78,5 +78,10 @@ namespace margelo::nitro::camera {
     auto __result = method(_javaPart, JFunc_void_std__shared_ptr_HybridMeteringPointSpec__cxx::fromCpp(onFocusCompleted));
     return __result->toCpp();
   }
+  ListenerSubscription JHybridTapToFocusGestureControllerSpec::addOnFocusResetListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusReset) {
+    static const auto method = _javaPart->javaClassStatic()->getMethod<jni::local_ref<JListenerSubscription>(jni::alias_ref<JFunc_void_std__shared_ptr_HybridMeteringPointSpec_::javaobject> /* onFocusReset */)>("addOnFocusResetListener_cxx");
+    auto __result = method(_javaPart, JFunc_void_std__shared_ptr_HybridMeteringPointSpec__cxx::fromCpp(onFocusReset));
+    return __result->toCpp();
+  }
 
 } // namespace margelo::nitro::camera

--- a/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridTapToFocusGestureControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/c++/JHybridTapToFocusGestureControllerSpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::camera {
     // Methods
     ListenerSubscription addOnTapListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onTap) override;
     ListenerSubscription addOnFocusCompletedListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusCompleted) override;
+    ListenerSubscription addOnFocusResetListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusReset) override;
 
   private:
     jni::global_ref<JHybridTapToFocusGestureControllerSpec::JavaPart> _javaPart;

--- a/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridTapToFocusGestureControllerSpec.kt
+++ b/packages/react-native-vision-camera/nitrogen/generated/android/kotlin/com/margelo/nitro/camera/HybridTapToFocusGestureControllerSpec.kt
@@ -47,6 +47,15 @@ abstract class HybridTapToFocusGestureControllerSpec: HybridGestureControllerSpe
     return __result
   }
 
+  abstract fun addOnFocusResetListener(onFocusReset: (point: HybridMeteringPointSpec) -> Unit): ListenerSubscription
+
+  @DoNotStrip
+  @Keep
+  private fun addOnFocusResetListener_cxx(onFocusReset: Func_void_std__shared_ptr_HybridMeteringPointSpec_): ListenerSubscription {
+    val __result = addOnFocusResetListener(onFocusReset)
+    return __result
+  }
+
   // Default implementation of `HybridObject.toString()`
   override fun toString(): String {
     return "[HybridObject TapToFocusGestureController]"

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridTapToFocusGestureControllerSpecSwift.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/c++/HybridTapToFocusGestureControllerSpecSwift.hpp
@@ -92,6 +92,14 @@ namespace margelo::nitro::camera {
       auto __value = std::move(__result.value());
       return __value;
     }
+    inline ListenerSubscription addOnFocusResetListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusReset) override {
+      auto __result = _swiftPart.addOnFocusResetListener(onFocusReset);
+      if (__result.hasError()) [[unlikely]] {
+        std::rethrow_exception(__result.error());
+      }
+      auto __value = std::move(__result.value());
+      return __value;
+    }
 
   private:
     VisionCamera::HybridTapToFocusGestureControllerSpec_cxx _swiftPart;

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridTapToFocusGestureControllerSpec.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridTapToFocusGestureControllerSpec.swift
@@ -15,6 +15,7 @@ public protocol HybridTapToFocusGestureControllerSpec_protocol: HybridObject, Hy
   // Methods
   func addOnTapListener(onTap: @escaping (_ point: (any HybridMeteringPointSpec)) -> Void) throws -> ListenerSubscription
   func addOnFocusCompletedListener(onFocusCompleted: @escaping (_ point: (any HybridMeteringPointSpec)) -> Void) throws -> ListenerSubscription
+  func addOnFocusResetListener(onFocusReset: @escaping (_ point: (any HybridMeteringPointSpec)) -> Void) throws -> ListenerSubscription
 }
 
 public extension HybridTapToFocusGestureControllerSpec_protocol {

--- a/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridTapToFocusGestureControllerSpec_cxx.swift
+++ b/packages/react-native-vision-camera/nitrogen/generated/ios/swift/HybridTapToFocusGestureControllerSpec_cxx.swift
@@ -166,4 +166,24 @@ open class HybridTapToFocusGestureControllerSpec_cxx : HybridGestureControllerSp
       return bridge.create_Result_ListenerSubscription_(__exceptionPtr)
     }
   }
+
+  @inline(__always)
+  public final func addOnFocusResetListener(onFocusReset: bridge.Func_void_std__shared_ptr_HybridMeteringPointSpec_) -> bridge.Result_ListenerSubscription_ {
+    do {
+      let __result = try self.__implementation.addOnFocusResetListener(onFocusReset: { () -> ((any HybridMeteringPointSpec)) -> Void in
+        let __wrappedFunction = bridge.wrap_Func_void_std__shared_ptr_HybridMeteringPointSpec_(onFocusReset)
+        return { (__point: (any HybridMeteringPointSpec)) -> Void in
+          __wrappedFunction.call({ () -> bridge.std__shared_ptr_HybridMeteringPointSpec_ in
+            let __cxxWrapped = __point.getCxxWrapper()
+            return __cxxWrapped.getCxxPart()
+          }())
+        }
+      }())
+      let __resultCpp = __result
+      return bridge.create_Result_ListenerSubscription_(__resultCpp)
+    } catch (let __error) {
+      let __exceptionPtr = __error.toCpp()
+      return bridge.create_Result_ListenerSubscription_(__exceptionPtr)
+    }
+  }
 }

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridTapToFocusGestureControllerSpec.cpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridTapToFocusGestureControllerSpec.cpp
@@ -17,6 +17,7 @@ namespace margelo::nitro::camera {
     registerHybrids(this, [](Prototype& prototype) {
       prototype.registerHybridMethod("addOnTapListener", &HybridTapToFocusGestureControllerSpec::addOnTapListener);
       prototype.registerHybridMethod("addOnFocusCompletedListener", &HybridTapToFocusGestureControllerSpec::addOnFocusCompletedListener);
+      prototype.registerHybridMethod("addOnFocusResetListener", &HybridTapToFocusGestureControllerSpec::addOnFocusResetListener);
     });
   }
 

--- a/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridTapToFocusGestureControllerSpec.hpp
+++ b/packages/react-native-vision-camera/nitrogen/generated/shared/c++/HybridTapToFocusGestureControllerSpec.hpp
@@ -59,6 +59,7 @@ namespace margelo::nitro::camera {
       // Methods
       virtual ListenerSubscription addOnTapListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onTap) = 0;
       virtual ListenerSubscription addOnFocusCompletedListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusCompleted) = 0;
+      virtual ListenerSubscription addOnFocusResetListener(const std::function<void(const std::shared_ptr<HybridMeteringPointSpec>& /* point */)>& onFocusReset) = 0;
 
     protected:
       // Hybrid Setup

--- a/packages/react-native-vision-camera/src/specs/gestures/TapToFocusGestureController.nitro.ts
+++ b/packages/react-native-vision-camera/src/specs/gestures/TapToFocusGestureController.nitro.ts
@@ -30,4 +30,17 @@ export interface TapToFocusGestureController extends GestureController {
   addOnFocusCompletedListener(
     onFocusCompleted: (point: MeteringPoint) => void,
   ): ListenerSubscription
+
+  /**
+   * Adds a listener that is called after focus triggered by a native tap
+   * automatically resets.
+   *
+   * This is not called if the reset fails or the focus is superseded by a
+   * newer focus operation. Call
+   * {@linkcode ListenerSubscription.remove | remove()} on the returned
+   * subscription to stop receiving updates.
+   */
+  addOnFocusResetListener(
+    onFocusReset: (point: MeteringPoint) => void,
+  ): ListenerSubscription
 }


### PR DESCRIPTION
## Summary

- add `addOnFocusResetListener` to the native tap-to-focus gesture controller
- emit after `MeteringTask` successfully performs its automatic reset on iOS
- explicitly schedule and await CameraX focus cancellation on Android so reset completion is observable
- invalidate pending automatic resets when a newer focus or manual reset supersedes the gesture

This PR is stacked on #4172. It intentionally reports automatic resets from native tap-to-focus gestures only; failed or superseded resets do not emit.

## Test plan

- `bun camera specs`
- `bun run lint-all`
- `bun camera typecheck`
- `bun camera build`
- `./apps/simple-camera/android/gradlew -p apps/simple-camera/android :react-native-vision-camera:assembleDebug --no-daemon --console=plain`
- `xcodebuild -workspace SimpleCamera.xcworkspace -scheme VisionCamera -sdk iphonesimulator -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath build CODE_SIGNING_ALLOWED=NO build -quiet`
