### PR TITLE
chore: Update links for the move to the margelo org

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,9 +20,9 @@ body:
           required: true
         - label: I have read the [VisionCamera Troubleshooting guide](https://visioncamera.margelo.com/docs).
           required: true
-        - label: I have searched [existing issues](https://github.com/mrousavy/react-native-vision-camera/issues?q=is%3Aissue) and found nothing matching.
+        - label: I have searched [existing issues](https://github.com/margelo/react-native-vision-camera/issues?q=is%3Aissue) and found nothing matching.
           required: true
-        - label: I am on the [latest version of react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera/releases), or have a specific reason I cannot upgrade.
+        - label: I am on the [latest version of react-native-vision-camera](https://github.com/margelo/react-native-vision-camera/releases), or have a specific reason I cannot upgrade.
           required: true
 
   - type: input
@@ -34,18 +34,18 @@ body:
 
         ### ✅ Preferred: open a PR with a failing harness test
 
-        Add the smallest possible `it(...)` block under [`apps/simple-camera/__tests__/`](https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera/__tests__) that reproduces the bug. Follow [the harness-tests README](https://github.com/mrousavy/react-native-vision-camera/blob/main/apps/simple-camera/__tests__/README.md) for the conventions — it explains where to put the test, how to write it against the `VisionCamera` imperative API, and the hard-vs-soft requirement rules.
+        Add the smallest possible `it(...)` block under [`apps/simple-camera/__tests__/`](https://github.com/margelo/react-native-vision-camera/tree/main/apps/simple-camera/__tests__) that reproduces the bug. Follow [the harness-tests README](https://github.com/margelo/react-native-vision-camera/blob/main/apps/simple-camera/__tests__/README.md) for the conventions — it explains where to put the test, how to write it against the `VisionCamera` imperative API, and the hard-vs-soft requirement rules.
 
         This is the fastest path to a fix: your PR's CI run is the reproduction (no maintainer setup needed), the maintainer can push a fix to the same branch until CI goes green, and both the fix and the regression test land together so the same bug can never come back silently.
 
-        Link the PR URL here. Example: `https://github.com/mrousavy/react-native-vision-camera/pull/1234`
+        Link the PR URL here. Example: `https://github.com/margelo/react-native-vision-camera/pull/1234`
 
         ### 🥈 Fallback: a reproduction repo
 
-        If the bug genuinely cannot be expressed as a harness test (for example, something specific to a `<Camera>` component with custom rendering that isn't covered by the imperative tests yet), fork this repo and modify the [`apps/simple-camera`](https://github.com/mrousavy/react-native-vision-camera/tree/main/apps/simple-camera) app, or start from a fresh `npx @react-native-community/cli init` and add only what's needed to show the bug. Link the repo URL here instead.
+        If the bug genuinely cannot be expressed as a harness test (for example, something specific to a `<Camera>` component with custom rendering that isn't covered by the imperative tests yet), fork this repo and modify the [`apps/simple-camera`](https://github.com/margelo/react-native-vision-camera/tree/main/apps/simple-camera) app, or start from a fresh `npx @react-native-community/cli init` and add only what's needed to show the bug. Link the repo URL here instead.
 
         Issues without either a PR link or a reproduction repo link are **invalid** and will be closed. Stripped-down snippets in the description do not count.
-      placeholder: "https://github.com/mrousavy/react-native-vision-camera/pull/<your-repro-PR>  (or a repo URL as fallback)"
+      placeholder: "https://github.com/margelo/react-native-vision-camera/pull/<your-repro-PR>  (or a repo URL as fallback)"
     validations:
       required: true
 
@@ -112,7 +112,7 @@ body:
       label: VisionCamera version
       description: |
         The exact version from your `package.json` (e.g. `5.2.1`).
-        See [Releases](https://github.com/mrousavy/react-native-vision-camera/releases) for the full list.
+        See [Releases](https://github.com/margelo/react-native-vision-camera/releases) for the full list.
       placeholder: "5.2.1"
     validations:
       required: true
@@ -198,7 +198,7 @@ body:
       label: Submission
       description: Please confirm each of the following about what you submitted above. Every box must be ticked.
       options:
-        - label: The reproduction I linked is either (preferred) a PR against this repo that adds a failing harness test following [the harness-tests README](https://github.com/mrousavy/react-native-vision-camera/blob/main/apps/simple-camera/__tests__/README.md), or (fallback) a public repo that reproduces the bug on a fresh clone. I understand the issue will be closed without one.
+        - label: The reproduction I linked is either (preferred) a PR against this repo that adds a failing harness test following [the harness-tests README](https://github.com/margelo/react-native-vision-camera/blob/main/apps/simple-camera/__tests__/README.md), or (fallback) a public repo that reproduces the bug on a fresh clone. I understand the issue will be closed without one.
           required: true
         - label: I pasted logs as text (not screenshots).
           required: true

--- a/.github/ISSUE_TEMPLATE/build-error-android.yml
+++ b/.github/ISSUE_TEMPLATE/build-error-android.yml
@@ -24,7 +24,7 @@ body:
           required: true
         - label: I did a clean build — deleted `node_modules`, `android/build`, `android/.gradle`, `android/app/build`, and `~/.gradle/caches`, then reinstalled.
           required: true
-        - label: I searched [existing build-error issues](https://github.com/mrousavy/react-native-vision-camera/issues?q=is%3Aissue+label%3A%22%F0%9F%9B%A0%EF%B8%8F+build-error%22) and found nothing matching.
+        - label: I searched [existing build-error issues](https://github.com/margelo/react-native-vision-camera/issues?q=is%3Aissue+label%3A%22%F0%9F%9B%A0%EF%B8%8F+build-error%22) and found nothing matching.
           required: true
 
   - type: textarea
@@ -45,7 +45,7 @@ body:
       label: VisionCamera version
       description: |
         Exact version from `package.json` (e.g. `5.2.1`).
-        See [Releases](https://github.com/mrousavy/react-native-vision-camera/releases) for the full list.
+        See [Releases](https://github.com/margelo/react-native-vision-camera/releases) for the full list.
       placeholder: "5.2.1"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/build-error-ios.yml
+++ b/.github/ISSUE_TEMPLATE/build-error-ios.yml
@@ -24,7 +24,7 @@ body:
           required: true
         - label: I did a clean build — deleted `node_modules`, `ios/Pods`, `ios/build`, and Xcode's DerivedData, then reinstalled.
           required: true
-        - label: I searched [existing build-error issues](https://github.com/mrousavy/react-native-vision-camera/issues?q=is%3Aissue+label%3A%22%F0%9F%9B%A0%EF%B8%8F+build-error%22) and found nothing matching.
+        - label: I searched [existing build-error issues](https://github.com/margelo/react-native-vision-camera/issues?q=is%3Aissue+label%3A%22%F0%9F%9B%A0%EF%B8%8F+build-error%22) and found nothing matching.
           required: true
 
   - type: textarea
@@ -45,7 +45,7 @@ body:
       label: VisionCamera version
       description: |
         Exact version from `package.json` (e.g. `5.2.1`).
-        See [Releases](https://github.com/mrousavy/react-native-vision-camera/releases) for the full list.
+        See [Releases](https://github.com/margelo/react-native-vision-camera/releases) for the full list.
       placeholder: "5.2.1"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,7 +9,7 @@ body:
       label: Prerequisites
       description: Please confirm you've done each of these. Every box must be ticked.
       options:
-        - label: I have searched [existing issues](https://github.com/mrousavy/react-native-vision-camera/issues?q=is%3Aissue) for a similar request.
+        - label: I have searched [existing issues](https://github.com/margelo/react-native-vision-camera/issues?q=is%3Aissue) for a similar request.
           required: true
 
   - type: textarea

--- a/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
+++ b/apps/simple-camera/__tests__/visioncamera.constraints.harness.ts
@@ -289,7 +289,7 @@ describe('VisionCamera - Constraints', () => {
     expect(previewEdges.long).toBeLessThanOrEqual(maxAllowedEdges.long)
   })
 
-  // Regression test for https://github.com/mrousavy/react-native-vision-camera/issues/4073:
+  // Regression test for https://github.com/margelo/react-native-vision-camera/issues/4073:
   // an explicitly listed resolutionBias for a recording output has a higher
   // priority than the auto-appended preview bias, so an app requesting
   // 1080p must record 1080p - not silently upgrade to 4k because the

--- a/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
+++ b/apps/simple-camera/__tests__/visioncamera.coordinates.harness.tsx
@@ -402,7 +402,7 @@ describe('VisionCamera - Coordinates', () => {
     }
   })
 
-  // Repro for https://github.com/mrousavy/react-native-vision-camera/issues/3871
+  // Repro for https://github.com/margelo/react-native-vision-camera/issues/3871
   it('round-trips Frame center -> Camera -> View center end-to-end', async () => {
     const session = await VisionCamera.createCameraSession(false)
     const previewOutput = VisionCamera.createPreviewOutput()
@@ -644,7 +644,7 @@ describe('VisionCamera - Coordinates', () => {
   // image space, while Frame.convertFramePointToCameraPoint consumes raw
   // buffer-space points. The center-only test above cannot catch an
   // off-center rectangle drifting after orientation is applied.
-  // See https://github.com/mrousavy/react-native-vision-camera/pull/3878.
+  // See https://github.com/margelo/react-native-vision-camera/pull/3878.
   it('maps oriented Frame rectangles into the same Camera bounds', async (context) => {
     const session = await VisionCamera.createCameraSession(false)
     const frameOutput = VisionCamera.createFrameOutput({

--- a/docs/content/docs/custom-native-camera-outputs.mdx
+++ b/docs/content/docs/custom-native-camera-outputs.mdx
@@ -5,7 +5,7 @@ description: Custom Swift/Kotlin CameraOutputs can be implemented in third-party
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 
-Third-party libraries can implement the [`CameraOutput`](/api/react-native-vision-camera/hybrid-objects/CameraOutput) class in native code to build a custom camera output that can be connected to the Camera just like any other output. This is achieved using [Nitro Modules](https://github.com/mrousavy/nitro) Hybrid Object inheritance - simply implement the native `HybridCameraOutputSpec`, and conform to the `NativeCameraOutput` interface/protocol:
+Third-party libraries can implement the [`CameraOutput`](/api/react-native-vision-camera/hybrid-objects/CameraOutput) class in native code to build a custom camera output that can be connected to the Camera just like any other output. This is achieved using [Nitro Modules](https://github.com/margelo/nitro) Hybrid Object inheritance - simply implement the native `HybridCameraOutputSpec`, and conform to the `NativeCameraOutput` interface/protocol:
 
 <Tabs items={["Swift (iOS)", "Kotlin (Android)"]} groupId="native-language">
 <Tab value="Swift (iOS)">
@@ -34,7 +34,7 @@ class MyCustomOutput: HybridCameraOutputSpec(), NativeCameraOutput {
 > The `NativeCameraOutput` interface/protocol requires you to implement methods and properties that expose the actual native `AVCaptureOutput`/`UseCase`, which will get used by the [`CameraSession`](/api/react-native-vision-camera/hybrid-objects/CameraSession).
 > Additionally, you can participate in resolution negotiations, and input/format requirements via these.
 
-Then, create a [Nitro Modules](https://github.com/mrousavy/nitro) `HybridObject` that returns a [`CameraOutput`](/api/react-native-vision-camera/hybrid-objects/CameraOutput):
+Then, create a [Nitro Modules](https://github.com/margelo/nitro) `HybridObject` that returns a [`CameraOutput`](/api/react-native-vision-camera/hybrid-objects/CameraOutput):
 
 ```ts
 import type { CameraOutput } from 'react-native-vision-camera'

--- a/docs/content/docs/native-frame-processor-plugins.mdx
+++ b/docs/content/docs/native-frame-processor-plugins.mdx
@@ -21,7 +21,7 @@ const frameOutput = useFrameOutput({
 
 ### Implementation
 
-Native Frame Processor Plugins are [Nitro Modules](https://github.com/mrousavy/nitro).
+Native Frame Processor Plugins are [Nitro Modules](https://github.com/margelo/nitro).
 
 #### 1. Bootstrap a Nitro Module
 
@@ -197,14 +197,14 @@ const frameOutput = useFrameOutput({
 })
 ```
 
-Thanks to [Nitro](https://github.com/mrousavy/nitro)'s powerful architecture, your Native Frame Processor Plugin can accept any kinds of arguments, return any kind of values (even a [`Frame`](/api/react-native-vision-camera/hybrid-objects/Frame)!), and even be asynchronous.
+Thanks to [Nitro](https://github.com/margelo/nitro)'s powerful architecture, your Native Frame Processor Plugin can accept any kinds of arguments, return any kind of values (even a [`Frame`](/api/react-native-vision-camera/hybrid-objects/Frame)!), and even be asynchronous.
 
 > [!TIP]
 > If your `HybridObject` needs arguments, you should create a separate `HybridObject` that acts as a factory and has a create-function for your `HybridObject` with arguments.
 
 ### C++ Plugins
 
-Because [Nitro](https://github.com/mrousavy/nitro) supports C++, you can also implement your Frame Processor Plugin in pure C++.
+Because [Nitro](https://github.com/margelo/nitro) supports C++, you can also implement your Frame Processor Plugin in pure C++.
 
 ```cpp title="HybridMyNativePlugin.hpp"
 #include <VisionCamera/HybridFrameSpec.hpp>

--- a/docs/content/docs/performance.mdx
+++ b/docs/content/docs/performance.mdx
@@ -5,7 +5,7 @@ description: Understanding what configurations affect Performance, and how to im
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs'
 
-VisionCamera's modern architecture, super-fast native bindings via [Nitro Modules](https://github.com/mrousavy/nitro), and best practices in-place allows it to be highly optimized for every Camera situation.
+VisionCamera's modern architecture, super-fast native bindings via [Nitro Modules](https://github.com/margelo/nitro), and best practices in-place allows it to be highly optimized for every Camera situation.
 As with all advanced tools, there are still ways to mis-use it. This guide covers common tips to improve Camera performance in VisionCamera.
 
 ### Simpler Camera Device

--- a/docs/src/lib/site-config.ts
+++ b/docs/src/lib/site-config.ts
@@ -7,7 +7,7 @@ export const siteConfig = {
     'The most powerful Camera library for React Native. Supports Photo and Video capture, QR/Barcode scanning, Frame Processors, and more.',
   alternateNames: ['React Native Vision Camera', 'react-native-vision-camera'],
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? DEFAULT_SITE_URL),
-  repositoryUrl: 'https://github.com/mrousavy/react-native-vision-camera',
+  repositoryUrl: 'https://github.com/margelo/react-native-vision-camera',
   packageUrl: 'https://www.npmjs.com/package/react-native-vision-camera',
   repositoryBranch: DEFAULT_BRANCH,
   contentRoots: {

--- a/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
+++ b/packages/react-native-vision-camera-barcode-scanner/VisionCameraBarcodeScanner.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => 15.5, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-vision-camera-barcode-scanner/package.json
+++ b/packages/react-native-vision-camera-barcode-scanner/package.json
@@ -53,12 +53,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com/api/react-native-vision-camera-barcode-scanner",
   "publishConfig": {

--- a/packages/react-native-vision-camera-location/VisionCameraLocation.podspec
+++ b/packages/react-native-vision-camera-location/VisionCameraLocation.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-vision-camera-location/package.json
+++ b/packages/react-native-vision-camera-location/package.json
@@ -52,12 +52,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com/api/react-native-vision-camera-location",
   "publishConfig": {

--- a/packages/react-native-vision-camera-resizer/VisionCameraResizer.podspec
+++ b/packages/react-native-vision-camera-resizer/VisionCameraResizer.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-vision-camera-resizer/package.json
+++ b/packages/react-native-vision-camera-resizer/package.json
@@ -57,12 +57,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com/api/react-native-vision-camera-resizer",
   "publishConfig": {

--- a/packages/react-native-vision-camera-skia/package.json
+++ b/packages/react-native-vision-camera-skia/package.json
@@ -40,12 +40,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com/api/react-native-vision-camera-skia",
   "publishConfig": {

--- a/packages/react-native-vision-camera-worklets/VisionCameraWorklets.podspec
+++ b/packages/react-native-vision-camera-worklets/VisionCameraWorklets.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-vision-camera-worklets/package.json
+++ b/packages/react-native-vision-camera-worklets/package.json
@@ -53,12 +53,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com/api/react-native-vision-camera-worklets",
   "publishConfig": {

--- a/packages/react-native-vision-camera/README.md
+++ b/packages/react-native-vision-camera/README.md
@@ -6,7 +6,7 @@ This is VisionCamera Core. Install it through npm:
 npm install react-native-vision-camera
 ```
 
-VisionCamera Core depends on [react-native-nitro-modules](https://github.com/mrousavy/nitro) and [react-native-nitro-image](https://github.com/mrousavy/react-native-nitro-image) - install those dependencies:
+VisionCamera Core depends on [react-native-nitro-modules](https://github.com/margelo/nitro) and [react-native-nitro-image](https://github.com/mrousavy/react-native-nitro-image) - install those dependencies:
 
 ```sh
 npm install react-native-nitro-modules react-native-nitro-image

--- a/packages/react-native-vision-camera/VisionCamera.podspec
+++ b/packages/react-native-vision-camera/VisionCamera.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => min_ios_version_supported, :visionos => 1.0 }
-  s.source       = { :git => "https://github.com/mrousavy/nitro.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/margelo/react-native-vision-camera.git", :tag => "#{s.version}" }
 
   s.source_files = [
     # Implementation (Swift)

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ViewGroup+installHierarchyFitter.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/extensions/ViewGroup+installHierarchyFitter.kt
@@ -1,4 +1,4 @@
-package com.mrousavy.camera.react.extensions
+package com.margelo.nitro.camera.extensions
 
 import android.view.View
 import android.view.ViewGroup

--- a/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/views/HybridPreviewView.kt
+++ b/packages/react-native-vision-camera/android/src/main/java/com/margelo/nitro/camera/views/HybridPreviewView.kt
@@ -21,13 +21,13 @@ import com.margelo.nitro.camera.PreviewResizeMode
 import com.margelo.nitro.camera.extensions.convertPoint
 import com.margelo.nitro.camera.extensions.converters.toImplementationMode
 import com.margelo.nitro.camera.extensions.converters.toScaleType
+import com.margelo.nitro.camera.extensions.installHierarchyFitter
 import com.margelo.nitro.camera.hybrids.metering.HybridMeteringPoint
 import com.margelo.nitro.camera.public.NativeGestureController
 import com.margelo.nitro.camera.public.NativePreviewOutput
 import com.margelo.nitro.core.Promise
 import com.margelo.nitro.image.HybridImage
 import com.margelo.nitro.image.HybridImageSpec
-import com.mrousavy.camera.react.extensions.installHierarchyFitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/packages/react-native-vision-camera/package.json
+++ b/packages/react-native-vision-camera/package.json
@@ -57,12 +57,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mrousavy/react-native-vision-camera.git"
+    "url": "git+https://github.com/margelo/react-native-vision-camera.git"
   },
   "author": "Marc Rousavy <me@mrousavy.com> (https://github.com/mrousavy)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mrousavy/react-native-vision-camera/issues"
+    "url": "https://github.com/margelo/react-native-vision-camera/issues"
   },
   "homepage": "https://visioncamera.margelo.com",
   "publishConfig": {


### PR DESCRIPTION
VisionCamera moved from `mrousavy/react-native-vision-camera` to `margelo/react-native-vision-camera`. GitHub keeps the old paths redirecting, so nothing is broken today, but the metadata should point at the canonical repo.

## What changed

| Area | Change |
| --- | --- |
| `packages/*/package.json` (6) | `repository.url` + `bugs.url` -> margelo |
| `docs/src/lib/site-config.ts` | `repositoryUrl` -> margelo. This one feeds the "Edit on GitHub" links on every docs page and the `codeRepository`/`sameAs` fields in the JSON-LD, so it was the highest-leverage single line |
| `.github/ISSUE_TEMPLATE/*.yml` (4) | Repro instructions, releases links, issue-search links |
| `apps/simple-camera/__tests__/*` (2) | Issue/PR links in regression-test comments |
| `packages/*/*.podspec` (5) | `s.source` pointed at `github.com/mrousavy/nitro.git` - a copy-paste leftover from the nitro podspec template. Now points at this repo |
| docs + `packages/react-native-vision-camera/README.md` | Nitro links, since `mrousavy/nitro` also moved to `margelo/nitro` |
| `ViewGroup+installHierarchyFitter.kt` | Declared `package com.mrousavy.camera.react.extensions` while sitting in `com/margelo/nitro/camera/extensions/`. Renamed to match the directory, and updated the one import in `HybridPreviewView.kt` |

## Deliberately left alone

- `github.com/mrousavy/react-native-nitro-image` and `github.com/mrousavy/react-native-data-scanner` - both verified still under `mrousavy` via the GitHub API.
- `nitrogen/generated/**` headers referencing `mrousavy/nitro` (~910 of them). Codegen output; they get rewritten when nitrogen regenerates.
- `author` fields, `mrousavy.com`, Twitter, and the ShadowLens links. Personal attribution, still accurate.

## Verification

- `bun x @biomejs/biome check` output is byte-identical to `main` (all 17 findings pre-existing).
- `bun run lint-kotlin` passes.
- Every remaining `mrousavy` hit in the tree was reviewed and is either personal attribution or a repo that genuinely still lives under `mrousavy`.

## Follow-ups that are not code (see PR discussion)

The AWS Device Farm OIDC trust policy, repo Actions setting, and npm ownership all need changes outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)