### PR TITLE
fix(ios): use connection rotation for frame coordinates

### DIFF
--- a/packages/react-native-vision-camera/ios/Delegates/FrameDelegate.swift
+++ b/packages/react-native-vision-camera/ios/Delegates/FrameDelegate.swift
@@ -9,7 +9,7 @@ import AVFoundation
 import Foundation
 
 final class FrameDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
-  var onFrame: ((CMSampleBuffer, CMTime, CameraOrientation, Bool) -> Void)?
+  var onFrame: ((CMSampleBuffer, CMTime, CameraOrientation, Bool, CameraOrientation) -> Void)?
   var onFrameDropped: ((CMSampleBuffer) -> Void)?
 
   func captureOutput(
@@ -28,7 +28,7 @@ final class FrameDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegat
     if let onFrame {
       onFrame(
         sampleBuffer, sampleBuffer.presentationTimeStamp, connection.orientation,
-        connection.isVideoMirrored)
+        connection.isVideoMirrored, connection.physicalBufferRotation)
     }
   }
 }

--- a/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureConnection+orientation.swift
+++ b/packages/react-native-vision-camera/ios/Extensions/AVFoundation/AVCaptureConnection+orientation.swift
@@ -13,6 +13,17 @@ extension AVCaptureConnection {
     return CameraOrientation(avOrientation: videoOrientation)
   }
 
+  var physicalBufferRotation: CameraOrientation {
+    #if os(iOS)
+      if #available(iOS 17.0, *) {
+        return CameraOrientation(degrees: Int(videoRotationAngle))
+      }
+    #endif
+    // videoRotationAngle is unavailable before iOS 17 and on visionOS.
+    // Preserve the existing videoOrientation-based behavior on those targets.
+    return orientation
+  }
+
   func setOrientation(_ orientation: CameraOrientation) throws {
     guard self.isVideoOrientationSupported else {
       throw RuntimeError.error(

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Image Types/HybridFrame.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Image Types/HybridFrame.swift
@@ -151,8 +151,8 @@ final class HybridFrame: HybridFrameSpec, NativeFrame, LazyLockableBuffer {
     }
     let matrix = FrameCoordinateSystemConverter.getCameraToFrameMatrix(
       pixelBuffer: pixelBuffer,
-      orientation: orientation,
-      isMirrored: isMirrored)
+      orientation: metadata.physicalBufferRotation,
+      isMirrored: metadata.isPhysicalBufferMirrored)
     return cameraPoint.applying(matrix)
   }
 
@@ -162,8 +162,8 @@ final class HybridFrame: HybridFrameSpec, NativeFrame, LazyLockableBuffer {
     }
     let matrix = FrameCoordinateSystemConverter.getFrameToCameraMatrix(
       pixelBuffer: pixelBuffer,
-      orientation: orientation,
-      isMirrored: isMirrored)
+      orientation: metadata.physicalBufferRotation,
+      isMirrored: metadata.isPhysicalBufferMirrored)
     return framePoint.applying(matrix)
   }
 }

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraFrameOutput.swift
@@ -120,7 +120,8 @@ final class HybridCameraFrameOutput: HybridCameraFrameOutputSpec, NativeCameraOu
   private func getMediaSampleMetadata(
     at timestamp: CMTime,
     orientation bufferOrientation: CameraOrientation,
-    isMirrored isBufferMirrored: Bool
+    isMirrored isBufferMirrored: Bool,
+    physicalBufferRotation: CameraOrientation
   ) -> MediaSampleMetadata {
     // `isMirrored` is relative; if the buffer is already mirrored & we want mirror, good.
     // If not, we need to counter-mirror.
@@ -142,7 +143,9 @@ final class HybridCameraFrameOutput: HybridCameraFrameOutputSpec, NativeCameraOu
     return MediaSampleMetadata(
       timestamp: timestamp,
       orientation: relativeOrientation,
-      isMirrored: isMirrored)
+      isMirrored: isMirrored,
+      physicalBufferRotation: physicalBufferRotation,
+      isPhysicalBufferMirrored: isBufferMirrored)
   }
 
   func setOnFrameCallback(onFrame: ((any HybridFrameSpec) -> Bool)?) throws {
@@ -151,12 +154,14 @@ final class HybridCameraFrameOutput: HybridCameraFrameOutputSpec, NativeCameraOu
         withMessage: "setOnFrameCallback(...) must be called on the FrameOutput's `thread`!")
     }
     if let onFrame {
-      delegate.onFrame = { (sampleBuffer, timestamp, bufferOrientation, isBufferMirrored) in
+      delegate.onFrame = {
+        (sampleBuffer, timestamp, bufferOrientation, isBufferMirrored, physicalBufferRotation) in
         // Prepare Frame + Metadata
         let metadata = self.getMediaSampleMetadata(
           at: timestamp,
           orientation: bufferOrientation,
-          isMirrored: isBufferMirrored)
+          isMirrored: isBufferMirrored,
+          physicalBufferRotation: physicalBufferRotation)
         let frame = HybridFrame(
           buffer: sampleBuffer,
           metadata: metadata)

--- a/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
+++ b/packages/react-native-vision-camera/ios/Hybrid Objects/Outputs/HybridCameraVideoFrameOutput.swift
@@ -72,7 +72,7 @@ final class HybridCameraVideoFrameOutput: HybridCameraVideoOutputSpec, NativeCam
       output.preservesDynamicHDRMetadata = true
     }
     // set the delegate to append to the Recorder
-    delegate.onFrame = { [weak self] buffer, timestamp, orientation, isMirrored in
+    delegate.onFrame = { [weak self] buffer, _, _, _, _ in
       guard let self else { return }
       self.onFrame(buffer, type: .video)
     }

--- a/packages/react-native-vision-camera/ios/Public/MediaSampleMetadata.swift
+++ b/packages/react-native-vision-camera/ios/Public/MediaSampleMetadata.swift
@@ -14,6 +14,8 @@ public struct MediaSampleMetadata {
   let timestamp: CMTime
   let orientation: CameraOrientation
   let isMirrored: Bool
+  let physicalBufferRotation: CameraOrientation
+  let isPhysicalBufferMirrored: Bool
 
   init(timestamp: CMTime, orientationFromOutput output: AVCaptureOutput) throws {
     guard let connection = output.connection(with: .video) else {
@@ -22,14 +24,34 @@ public struct MediaSampleMetadata {
     self.init(timestamp: timestamp, orientationFromConnection: connection)
   }
   init(timestamp: CMTime, orientationFromConnection connection: AVCaptureConnection) {
-    self.timestamp = timestamp
-    self.orientation = connection.orientation
-    self.isMirrored = connection.isVideoMirrored
+    let isMirrored = connection.isVideoMirrored
+    self.init(
+      timestamp: timestamp,
+      orientation: connection.orientation,
+      isMirrored: isMirrored,
+      physicalBufferRotation: connection.physicalBufferRotation,
+      isPhysicalBufferMirrored: isMirrored)
   }
   init(timestamp: CMTime, orientation: CameraOrientation, isMirrored: Bool) {
+    self.init(
+      timestamp: timestamp,
+      orientation: orientation,
+      isMirrored: isMirrored,
+      physicalBufferRotation: orientation,
+      isPhysicalBufferMirrored: isMirrored)
+  }
+  init(
+    timestamp: CMTime,
+    orientation: CameraOrientation,
+    isMirrored: Bool,
+    physicalBufferRotation: CameraOrientation,
+    isPhysicalBufferMirrored: Bool
+  ) {
     self.timestamp = timestamp
     self.orientation = orientation
     self.isMirrored = isMirrored
+    self.physicalBufferRotation = physicalBufferRotation
+    self.isPhysicalBufferMirrored = isPhysicalBufferMirrored
   }
 
   var uiImageOrientation: UIImage.Orientation {


### PR DESCRIPTION
## Summary

- keep the public output-relative `Frame.orientation` and `Frame.isMirrored` semantics unchanged
- capture the physical rotation and mirroring applied to each delivered iOS video buffer
- use those physical values for Frame ↔ Camera coordinate conversion

This replaces the closed #4175 with a smaller, data-driven fix for #4114.

## Why

`AVCaptureVideoPreviewLayer` converts capture-device points in the camera's unrotated image space, while `AVCaptureVideoDataOutput` can physically rotate and mirror delivered buffers. The converter previously received the public output-relative orientation/mirroring values, so Frame and PreviewView did not necessarily refer to the same intermediate coordinate space.

The prior PR attempted to bridge the spaces by assuming every camera's native sensor orientation was `.left`. That is not valid across devices. This version reads the connection's actual `videoRotationAngle` on iOS 17+ instead. Apple explicitly documents that the default can be 180° on newer front-camera iPads and recommends accounting for the connection's default rotation. Older iOS and visionOS retain the existing `videoOrientation` behavior because `videoRotationAngle` is unavailable there.

- [`AVCaptureConnection.videoRotationAngle`](https://developer.apple.com/documentation/avfoundation/avcaptureconnection/videorotationangle)
- [`AVCaptureVideoPreviewLayer.layerPointConverted(fromCaptureDevicePoint:)`](https://developer.apple.com/documentation/avfoundation/avcapturevideopreviewlayer/layerpointconverted(fromcapturedevicepoint:))

No Android code or public API is changed.

## Verification

- existing merged Harness regression `maps a square Frame region onto a square View region` remains the end-to-end CI oracle
- task-local affine regression: fixed composition ratio `1.0`; old output-relative wiring `3.1604938271604937`; 180° connection default and inverse round-trip pass
- `bun camera typecheck`
- `bun lint-swift`
- `xcodebuild -project apps/simple-camera/ios/Pods/Pods.xcodeproj -scheme VisionCamera -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` (arm64 + x86_64)
- `git diff --check`

The physical-camera Harness run remains the final end-to-end check, especially for a Spring 2024+ front-camera iPad.

Fixes #4114.
Replaces #4175.
